### PR TITLE
Fix: Adjust flush timing for nested generations using outermost_lock_context

### DIFF
--- a/lilypad/generations.py
+++ b/lilypad/generations.py
@@ -82,16 +82,11 @@ def manual_flush_context(flush: bool) -> Generator[None, None, None]:
         yield
         return
     processor = _get_batch_span_processor()
-    old_delay = None
-    if processor is not None:
-        old_delay = processor.schedule_delay_millis
-        processor.schedule_delay_millis = 10**12  # Effectively disable auto flush.
-    try:
+    if not processor:
         yield
-    finally:
-        if processor is not None and old_delay is not None:
-            processor.force_flush()
-            processor.schedule_delay_millis = old_delay
+        return
+    with processor.condition:
+        yield
 
 
 def _construct_trace_attributes(


### PR DESCRIPTION
Fixes: https://github.com/Mirascope/lilypad/issues/176

Overview:
Fix the issue where spans in nested generations are flushed prematurely, causing foreign key constraint failures due to missing parent spans.

Changes:
- Modified the flush logic so that only the outermost generation performs a flush, while inner generations do not trigger a flush.
- Renamed and updated the context manager from `manual_flush_context()` to outermost_lock_context(). When enabled for the outermost generation (`enable_lock=True`), `outermost_lock_context()` acquires the BatchSpanProcessor's condition lock (via "with processor.condition:") to synchronize flush operations. This ensures that flush occurs only once at the end of the outermost generation.
- Updated the generation() decorator to use outermost_lock_context(is_outermost) appropriately, ensuring that flush is executed only for the outermost generation.

Effect:
This change ensures that all spans are sent only after the entire nested generation has completed, preserving the parent-child relationships and avoiding foreign key constraint issues.
