### PR TITLE
feat: Use __qualname__ for Generation Spans and Closure Names for Improved Traceability

### DIFF
--- a/lilypad/_utils/__init__.py
+++ b/lilypad/_utils/__init__.py
@@ -1,7 +1,7 @@
 """Utilities for the `lilypad` module."""
 
 from .call_safely import call_safely
-from .closure import Closure, DependencyInfo
+from .closure import Closure, DependencyInfo, get_qualified_name
 from .config import load_config
 from .functions import create_mirascope_call, inspect_arguments
 from .middleware import create_mirascope_middleware, encode_gemini_part
@@ -13,6 +13,7 @@ __all__ = [
     "create_mirascope_call",
     "create_mirascope_middleware",
     "encode_gemini_part",
+    "get_qualified_name",
     "inspect_arguments",
     "load_config",
 ]

--- a/lilypad/_utils/closure.py
+++ b/lilypad/_utils/closure.py
@@ -36,6 +36,11 @@ class DependencyInfo(TypedDict):
     version: str
     extras: list[str] | None
 
+def get_qualified_name(fn: Callable) -> str:
+    qualified_name = fn.__qualname__.split("<locals>.")
+    if len(qualified_name) > 1:
+        return qualified_name[1]
+    return qualified_name[0]
 
 def _is_third_party(module: ModuleType, site_packages: set[str]) -> bool:
     module_file = getattr(module, "__file__", None)
@@ -781,7 +786,7 @@ class Closure(BaseModel):
         formatted_code = _run_ruff(code)
         hash_value = hashlib.sha256(formatted_code.encode("utf-8")).hexdigest()
         return cls(
-            name=fn.__qualname__,
+            name=get_qualified_name(fn),
             signature=_run_ruff(_clean_source_code(fn, exclude_fn_body=True)).strip(),
             code=formatted_code,
             hash=hash_value,

--- a/lilypad/_utils/closure.py
+++ b/lilypad/_utils/closure.py
@@ -781,7 +781,7 @@ class Closure(BaseModel):
         formatted_code = _run_ruff(code)
         hash_value = hashlib.sha256(formatted_code.encode("utf-8")).hexdigest()
         return cls(
-            name=fn.__name__,
+            name=fn.__qualname__,
             signature=_run_ruff(_clean_source_code(fn, exclude_fn_body=True)).strip(),
             code=formatted_code,
             hash=hash_value,

--- a/lilypad/_utils/closure.py
+++ b/lilypad/_utils/closure.py
@@ -36,11 +36,13 @@ class DependencyInfo(TypedDict):
     version: str
     extras: list[str] | None
 
+
 def get_qualified_name(fn: Callable) -> str:
     qualified_name = fn.__qualname__.split("<locals>.")
     if len(qualified_name) > 1:
         return qualified_name[1]
     return qualified_name[0]
+
 
 def _is_third_party(module: ModuleType, site_packages: set[str]) -> bool:
     module_file = getattr(module, "__file__", None)

--- a/lilypad/generations.py
+++ b/lilypad/generations.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel
 from ._utils import (
     call_safely,
     create_mirascope_middleware,
+    get_qualified_name,
     inspect_arguments,
     load_config,
 )
@@ -125,7 +126,6 @@ def _construct_trace_attributes(
         "lilypad.is_async": is_async,
     }
 
-
 def _trace(
     generation: GenerationPublic,
     arg_types: dict[str, str],
@@ -148,7 +148,7 @@ def _trace(
             @wraps(fn)
             async def inner_async(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 with get_tracer("lilypad").start_as_current_span(
-                    f"{fn.__qualname__}"
+                        get_qualified_name(fn)
                 ) as span:
                     output = await fn(*args, **kwargs)
                     attributes: dict[str, AttributeValue] = _construct_trace_attributes(
@@ -164,7 +164,7 @@ def _trace(
             @wraps(fn)
             def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 with get_tracer("lilypad").start_as_current_span(
-                    f"{fn.__qualname__}"
+                      get_qualified_name(fn)
                 ) as span:
                     output = fn(*args, **kwargs)
                     attributes: dict[str, AttributeValue] = _construct_trace_attributes(

--- a/lilypad/generations.py
+++ b/lilypad/generations.py
@@ -126,6 +126,7 @@ def _construct_trace_attributes(
         "lilypad.is_async": is_async,
     }
 
+
 def _trace(
     generation: GenerationPublic,
     arg_types: dict[str, str],
@@ -148,7 +149,7 @@ def _trace(
             @wraps(fn)
             async def inner_async(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 with get_tracer("lilypad").start_as_current_span(
-                        get_qualified_name(fn)
+                    get_qualified_name(fn)
                 ) as span:
                     output = await fn(*args, **kwargs)
                     attributes: dict[str, AttributeValue] = _construct_trace_attributes(
@@ -164,7 +165,7 @@ def _trace(
             @wraps(fn)
             def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 with get_tracer("lilypad").start_as_current_span(
-                      get_qualified_name(fn)
+                    get_qualified_name(fn)
                 ) as span:
                     output = fn(*args, **kwargs)
                     attributes: dict[str, AttributeValue] = _construct_trace_attributes(

--- a/lilypad/generations.py
+++ b/lilypad/generations.py
@@ -148,7 +148,7 @@ def _trace(
             @wraps(fn)
             async def inner_async(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 with get_tracer("lilypad").start_as_current_span(
-                    f"{fn.__name__}"
+                    f"{fn.__qualname__}"
                 ) as span:
                     output = await fn(*args, **kwargs)
                     attributes: dict[str, AttributeValue] = _construct_trace_attributes(
@@ -164,7 +164,7 @@ def _trace(
             @wraps(fn)
             def inner(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 with get_tracer("lilypad").start_as_current_span(
-                    f"{fn.__name__}"
+                    f"{fn.__qualname__}"
                 ) as span:
                     output = fn(*args, **kwargs)
                     attributes: dict[str, AttributeValue] = _construct_trace_attributes(


### PR DESCRIPTION
Fixes: https://github.com/Mirascope/lilypad/issues/191