### PR TITLE
fix: Broaden isLilypadCloud detection to cover all *.lilypad.so subdomains

### DIFF
--- a/client/src/ee/utils/common.ts
+++ b/client/src/ee/utils/common.ts
@@ -1,3 +1,5 @@
 export const isLilypadCloud = (): boolean => {
-  return window.location.hostname === "app.lilypad.so";
+  const hostname = window.location.hostname;
+  const domainSuffix = ".lilypad.so";
+  return hostname.endsWith(domainSuffix);
 };


### PR DESCRIPTION
Fixies: https://linear.app/mirascope/issue/LILY-134/playground-not-available-on-free-plan-cloud