### PR TITLE
refactor: simplify comments schema and enhance timezone handling in tests

### DIFF
--- a/app/lilypad/server/schemas/comments.py
+++ b/app/lilypad/server/schemas/comments.py
@@ -1,9 +1,9 @@
 """Comments schemas."""
 
-from datetime import datetime, timezone
+from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel
 
 from ..models.comments import _CommentBase
 
@@ -26,14 +26,5 @@ class CommentUpdate(BaseModel):
 class CommentPublic(_CommentBase):
     """Comment Public Model."""
 
-    model_config = ConfigDict(from_attributes=True)  # type: ignore[assignment]
-
     uuid: UUID
     created_at: datetime
-
-    @field_validator("updated_at", "created_at", mode="before")
-    def add_timezone_if_missing(cls, value: datetime | None) -> datetime | None:
-        """Add UTC timezone to naive datetimes from SQLite."""
-        if value and not value.tzinfo:
-            return value.replace(tzinfo=timezone.utc)
-        return value


### PR DESCRIPTION
Revert schema because it was still changed for unittest and fix unittest.