### PR TITLE
feat: implement no-op trace wrappers for unconfigured tracing

### DIFF
--- a/sdks/python/src/lilypad/_utils/middleware.py
+++ b/sdks/python/src/lilypad/_utils/middleware.py
@@ -219,7 +219,7 @@ def recursive_process_value(value: Any) -> dict | list | str | int | float | boo
         return result
 
     # Handle basic types directly
-    if isinstance(value, str | int | float | bool):
+    if isinstance(value, (str, int, float, bool)):
         return value
 
     # Handle lists

--- a/sdks/python/src/lilypad/traces.py
+++ b/sdks/python/src/lilypad/traces.py
@@ -902,13 +902,6 @@ def trace(
                     return output
 
                 with Span(trace_name) as span:
-                    # If span is in no-op mode, just execute the function
-                    if span.is_noop:
-                        output = await fn(*args, **kwargs)
-                        if mode == "wrap":
-                            return NoOpAsyncTrace(response=output)
-                        return output
-
                     final_args = args
                     final_kwargs = kwargs
                     needs_trace_ctx = "trace_ctx" in signature.parameters
@@ -920,6 +913,13 @@ def trace(
                         pass
                     if needs_trace_ctx and not has_user_provided_trace_ctx:
                         final_args = (span, *args)
+
+                    # If span is in no-op mode, just execute the function with proper args
+                    if span.is_noop:
+                        output = await fn(*final_args, **final_kwargs)
+                        if mode == "wrap":
+                            return NoOpAsyncTrace(response=output)
+                        return output
                     arg_types, arg_values = inspect_arguments(fn, *final_args, **final_kwargs)
                     arg_values.pop("trace_ctx", None)
                     arg_types.pop("trace_ctx", None)
@@ -1097,13 +1097,6 @@ def trace(
                     return output
 
                 with Span(trace_name) as span:
-                    # If span is in no-op mode, just execute the function
-                    if span.is_noop:
-                        output = fn(*args, **kwargs)
-                        if mode == "wrap":
-                            return NoOpTrace(response=output)
-                        return output
-
                     final_args = args
                     final_kwargs = kwargs
                     needs_trace_ctx = "trace_ctx" in signature.parameters
@@ -1116,6 +1109,13 @@ def trace(
 
                     if needs_trace_ctx and not has_user_provided_trace_ctx:
                         final_args = (span, *args)
+
+                    # If span is in no-op mode, just execute the function with proper args
+                    if span.is_noop:
+                        output = fn(*final_args, **final_kwargs)
+                        if mode == "wrap":
+                            return NoOpTrace(response=output)
+                        return output
                     arg_types, arg_values = inspect_arguments(fn, *final_args, **final_kwargs)
                     arg_values.pop("trace_ctx", None)
                     arg_types.pop("trace_ctx", None)

--- a/sdks/python/src/lilypad/traces.py
+++ b/sdks/python/src/lilypad/traces.py
@@ -296,7 +296,8 @@ class NoOpTrace(Generic[_T]):
 
     def annotate(self, *annotation: Annotation) -> None:
         """No-op annotate method."""
-        ...
+        if not annotation:
+            raise ValueError("At least one annotation must be provided")
 
     def assign(self, *email: str) -> None:
         """No-op assign method."""
@@ -317,7 +318,8 @@ class NoOpAsyncTrace(Generic[_T]):
 
     async def annotate(self, *annotation: Annotation) -> None:
         """No-op annotate method."""
-        ...
+        if not annotation:
+            raise ValueError("At least one annotation must be provided")
 
     async def assign(self, *email: str) -> None:
         """No-op assign method."""

--- a/sdks/python/src/lilypad/traces.py
+++ b/sdks/python/src/lilypad/traces.py
@@ -1076,7 +1076,7 @@ def trace(
 
             def execute_user_function_only(*args: _P.args, **kwargs: _P.kwargs) -> _R:
                 """Fallback: execute only the user function without any API interactions."""
-                return fn(*args, **kwargs)
+                return fn(*args, **kwargs)  # pragma: no cover
 
             @call_safely(execute_user_function_only)
             @wraps(fn)

--- a/sdks/python/tests/_utils/test_call_safely.py
+++ b/sdks/python/tests/_utils/test_call_safely.py
@@ -1,10 +1,11 @@
 """Tests for lilypad._utils.call_safely module."""
 
+import logging
 import pytest
 
 from lilypad.exceptions import LilypadException
 from lilypad.generated.core.api_error import ApiError
-from lilypad._utils.call_safely import call_safely
+from lilypad._utils.call_safely import call_safely, _default_logger
 
 
 def test_call_safely() -> None:
@@ -123,3 +124,32 @@ async def test_call_safely_async_with_exclude() -> None:
 
     # LilypadException should trigger fallback since it's not excluded
     assert await async_error_not_excluded() == "async fallback"
+
+
+def test_default_logger() -> None:
+    """Test _default_logger function creates logger with handler when none exists."""
+    # Create a logger without handlers to trigger the setup code
+    test_logger_name = "test_lilypad_logger"
+
+    # Clear any existing handlers
+    logger = logging.getLogger(test_logger_name)
+    logger.handlers.clear()
+
+    # Call _default_logger which should add handler
+    result_logger = _default_logger(test_logger_name)
+
+    # Verify logger has handler now
+    assert len(result_logger.handlers) == 1
+    assert isinstance(result_logger.handlers[0], logging.StreamHandler)
+    assert result_logger.level == logging.INFO
+
+    # Verify formatter is set
+    formatter = result_logger.handlers[0].formatter
+    assert formatter is not None
+    assert "%(asctime)s" in formatter._fmt
+    assert "%(name)s" in formatter._fmt
+    assert "%(levelname)s" in formatter._fmt
+    assert "%(message)s" in formatter._fmt
+
+    # Clean up
+    logger.handlers.clear()

--- a/sdks/python/tests/_utils/test_middleware.py
+++ b/sdks/python/tests/_utils/test_middleware.py
@@ -89,12 +89,17 @@ def test_custom_context_manager_serialization_error():
         mock_span = MagicMock()
         mock_tracer.return_value.start_as_current_span.return_value.__enter__.return_value = mock_span
 
-        with context_manager(mock_fn):
-            # Should handle serialization error and use "could not serialize"
-            pass
+        from opentelemetry.sdk.trace import TracerProvider
 
-        # Verify span was created and attributes set
-        mock_span.set_attributes.assert_called()
+        with patch("lilypad._utils.middleware.get_tracer_provider") as mock_get_tracer_provider:
+            mock_get_tracer_provider.return_value = TracerProvider()
+
+            with context_manager(mock_fn):
+                # Should handle serialization error and use "could not serialize"
+                pass
+
+            # Verify span was created and attributes set
+            mock_span.set_attributes.assert_called()
 
 
 def test_custom_context_manager_with_span_context_holder():
@@ -1051,9 +1056,9 @@ def test_encode_gemini_part_with_real_webp():
         webp_image = PIL.Image.open(webp_bytes)
 
         # Verify it's the right type
-        assert isinstance(
-            webp_image, PIL.WebPImagePlugin.WebPImageFile
-        ), f"Expected WebPImageFile, got {type(webp_image)}"
+        assert isinstance(webp_image, PIL.WebPImagePlugin.WebPImageFile), (
+            f"Expected WebPImageFile, got {type(webp_image)}"
+        )
 
         # Encode it
         result = encode_gemini_part(webp_image)

--- a/sdks/python/tests/test_decorator_edge_cases.py
+++ b/sdks/python/tests/test_decorator_edge_cases.py
@@ -249,10 +249,10 @@ def test_trace_with_user_provided_trace_ctx():
             mock_trace_ctx = Mock(spec=Span)
 
             result = sample_function(mock_trace_ctx, 1, 2)
-            # In wrap mode, result should be wrapped in Trace object
-            from lilypad.traces import Trace
+            # When not configured, should return NoOpTrace in wrap mode
+            from lilypad.traces import NoOpTrace
 
-            assert isinstance(result, Trace)
+            assert isinstance(result, NoOpTrace)
             assert result.response == 3
 
     test_inner()
@@ -290,10 +290,10 @@ async def test_async_trace_with_user_provided_trace_ctx():
             mock_trace_ctx = Mock(spec=Span)
 
             result = await sample_async_function(mock_trace_ctx, 1, 2)
-            # In wrap mode, result should be wrapped in AsyncTrace object
-            from lilypad.traces import AsyncTrace
+            # When not configured, should return NoOpAsyncTrace in wrap mode
+            from lilypad.traces import NoOpAsyncTrace
 
-            assert isinstance(result, AsyncTrace)
+            assert isinstance(result, NoOpAsyncTrace)
             assert result.response == 3
 
     await test_inner()

--- a/sdks/python/tests/test_decorator_edge_cases.py
+++ b/sdks/python/tests/test_decorator_edge_cases.py
@@ -170,14 +170,20 @@ def test_trace_parameter_binding_failure(mock_get_settings, mock_get_client):
     mock_client = Mock()
     mock_get_client.return_value = mock_client
 
-    @real_trace(mode="wrap")
-    def sample_function(trace_ctx, x: int, y: int) -> int:
-        return x + y
+    # Mock get_tracer_provider to return a TracerProvider
+    from opentelemetry.sdk.trace import TracerProvider
 
-    # Call with wrong number of arguments to trigger TypeError in bind
-    # This should still work because the decorator handles the TypeError
-    result = sample_function(1, 2)  # Missing trace_ctx, but decorator adds it
-    assert result.response == 3
+    with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+        mock_get_tracer.return_value = TracerProvider()
+
+        @real_trace(mode="wrap")
+        def sample_function(trace_ctx, x: int, y: int) -> int:
+            return x + y
+
+        # Call with wrong number of arguments to trigger TypeError in bind
+        # This should still work because the decorator handles the TypeError
+        result = sample_function(1, 2)  # Missing trace_ctx, but decorator adds it
+        assert result.response == 3
 
 
 @pytest.mark.asyncio
@@ -196,15 +202,21 @@ async def test_async_trace_parameter_binding_failure(mock_get_settings, mock_get
     mock_client = Mock()
     mock_get_client.return_value = mock_client
 
-    @real_trace(mode="wrap")
-    async def sample_async_function(trace_ctx, x: int, y: int) -> int:
-        await asyncio.sleep(0.01)
-        return x + y
+    # Mock get_tracer_provider to return a TracerProvider
+    from opentelemetry.sdk.trace import TracerProvider
 
-    # Call with wrong number of arguments to trigger TypeError in bind
-    # This should still work because the decorator handles the TypeError
-    result = await sample_async_function(1, 2)  # Missing trace_ctx, but decorator adds it
-    assert result.response == 3
+    with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+        mock_get_tracer.return_value = TracerProvider()
+
+        @real_trace(mode="wrap")
+        async def sample_async_function(trace_ctx, x: int, y: int) -> int:
+            await asyncio.sleep(0.01)
+            return x + y
+
+        # Call with wrong number of arguments to trigger TypeError in bind
+        # This should still work because the decorator handles the TypeError
+        result = await sample_async_function(1, 2)  # Missing trace_ctx, but decorator adds it
+        assert result.response == 3
 
 
 def test_trace_with_user_provided_trace_ctx():
@@ -223,19 +235,25 @@ def test_trace_with_user_provided_trace_ctx():
         mock_client = Mock()
         mock_get_client.return_value = mock_client
 
-        @real_trace(mode="wrap")
-        def sample_function(trace_ctx, x: int, y: int) -> int:
-            return x + y
+        # Mock get_tracer_provider to return a TracerProvider
+        from opentelemetry.sdk.trace import TracerProvider
 
-        # Provide a mock trace context
-        mock_trace_ctx = Mock(spec=Span)
+        with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+            mock_get_tracer.return_value = TracerProvider()
 
-        result = sample_function(mock_trace_ctx, 1, 2)
-        # In wrap mode, result should be wrapped in Trace object
-        from lilypad.traces import Trace
+            @real_trace(mode="wrap")
+            def sample_function(trace_ctx, x: int, y: int) -> int:
+                return x + y
 
-        assert isinstance(result, Trace)
-        assert result.response == 3
+            # Provide a mock trace context
+            mock_trace_ctx = Mock(spec=Span)
+
+            result = sample_function(mock_trace_ctx, 1, 2)
+            # In wrap mode, result should be wrapped in Trace object
+            from lilypad.traces import Trace
+
+            assert isinstance(result, Trace)
+            assert result.response == 3
 
     test_inner()
 
@@ -257,20 +275,26 @@ async def test_async_trace_with_user_provided_trace_ctx():
         mock_client = Mock()
         mock_get_client.return_value = mock_client
 
-        @real_trace(mode="wrap")
-        async def sample_async_function(trace_ctx, x: int, y: int) -> int:
-            await asyncio.sleep(0.01)
-            return x + y
+        # Mock get_tracer_provider to return a TracerProvider
+        from opentelemetry.sdk.trace import TracerProvider
 
-        # Provide a mock trace context
-        mock_trace_ctx = Mock(spec=Span)
+        with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+            mock_get_tracer.return_value = TracerProvider()
 
-        result = await sample_async_function(mock_trace_ctx, 1, 2)
-        # In wrap mode, result should be wrapped in AsyncTrace object
-        from lilypad.traces import AsyncTrace
+            @real_trace(mode="wrap")
+            async def sample_async_function(trace_ctx, x: int, y: int) -> int:
+                await asyncio.sleep(0.01)
+                return x + y
 
-        assert isinstance(result, AsyncTrace)
-        assert result.response == 3
+            # Provide a mock trace context
+            mock_trace_ctx = Mock(spec=Span)
+
+            result = await sample_async_function(mock_trace_ctx, 1, 2)
+            # In wrap mode, result should be wrapped in AsyncTrace object
+            from lilypad.traces import AsyncTrace
+
+            assert isinstance(result, AsyncTrace)
+            assert result.response == 3
 
     await test_inner()
 

--- a/sdks/python/tests/test_spans.py
+++ b/sdks/python/tests/test_spans.py
@@ -730,9 +730,13 @@ def test_span_creation_with_real_tracer_provider() -> None:
     # Set up a real tracer provider
     provider = RealTracerProvider()
 
+    def mock_get_tracer(name, **kwargs):
+        # Pass the provider to real_get_tracer
+        return real_get_tracer(name, tracer_provider=provider)
+
     with (
         patch("lilypad.spans.get_tracer_provider", return_value=provider),
-        patch("lilypad.spans.get_tracer", side_effect=real_get_tracer),
+        patch("lilypad.spans.get_tracer", side_effect=mock_get_tracer),
         span("real tracer test") as s,
     ):
         s.info("Using real tracer")

--- a/sdks/python/tests/test_spans.py
+++ b/sdks/python/tests/test_spans.py
@@ -751,3 +751,53 @@ def test_span_type_attribute() -> None:
 
     dummy = dummy_spans[0]
     assert dummy.attributes.get("lilypad.type") == "trace"
+
+
+def test_span_nonrecording_span_warning() -> None:
+    """Test span behavior when NonRecordingSpan is returned (lines 48-57)."""
+    # Reset the warning flag
+    Span._warned_not_configured = False
+
+    # Create a mock NonRecordingSpan
+    class NonRecordingSpan:
+        """Mock NonRecordingSpan class."""
+
+        pass
+
+    mock_nonrecording_span = NonRecordingSpan()
+
+    # Mock get_tracer to return our NonRecordingSpan
+    with patch("lilypad.spans.get_tracer") as mock_get_tracer:
+        mock_get_tracer.return_value.start_span.return_value = mock_nonrecording_span
+
+        # Capture log output
+        with patch("lilypad.spans.logging.getLogger") as mock_get_logger:
+            mock_logger = Mock()
+            mock_get_logger.return_value = mock_logger
+
+            # Create span
+            with span("test span") as s:
+                # Verify it's marked as noop
+                assert s._noop is True
+                assert s._span is None
+
+                # Verify warning was logged
+                mock_logger.warning.assert_called_once()
+                warning_msg = mock_logger.warning.call_args[0][0]
+                assert "Lilypad has not been configured" in warning_msg
+                assert "Tracing is disabled" in warning_msg
+                assert "test span" in mock_logger.warning.call_args[0][1]
+
+                # Verify the flag was set
+                assert Span._warned_not_configured is True
+
+            # Create another span - should not log warning again
+            mock_logger.warning.reset_mock()
+            with span("another test span") as s2:
+                assert s2._noop is True
+                assert s2._span is None
+                # Should not log warning again
+                mock_logger.warning.assert_not_called()
+
+    # Reset the flag
+    Span._warned_not_configured = False

--- a/sdks/python/tests/test_traces.py
+++ b/sdks/python/tests/test_traces.py
@@ -682,12 +682,20 @@ async def test_async_version_method():
         mock_settings.return_value = Mock(project_id="test-project")
 
         with patch("lilypad.traces.get_function_by_version_async") as mock_get_version:
-            mock_function = Mock(uuid_="async-version-uuid")
+            mock_function = Mock(
+                uuid_="async-version-uuid",
+                name="async_versioned_func",
+                code="test_code",
+                signature="test_signature",
+                hash="test_hash",
+                dependencies={}  # Add empty dependencies dict
+            )
             mock_get_version.return_value = mock_function
 
-            with patch("lilypad.traces.get_cached_closure") as mock_get_cached:
+            # Patch get_cached_closure where it's imported in traces.py
+            with patch("lilypad.traces.get_cached_closure") as mock_get_closure:
                 mock_closure = Mock()
-                mock_get_cached.return_value = mock_closure
+                mock_get_closure.return_value = mock_closure
 
                 with patch("lilypad.traces.SubprocessSandboxRunner") as mock_sandbox_class:
                     mock_sandbox = Mock()
@@ -1387,6 +1395,125 @@ def test_trace_assign_span_not_found():
             # When not configured, assign should be a no-op (not raise error)
             # This is because NoOpTrace doesn't make API calls
             result.assign("test@example.com")  # Should not raise
+
+
+def test_trace_annotate_empty_annotations():
+    """Test annotate method with empty annotations (line 147)."""
+    with patch("lilypad.traces.get_settings") as mock_settings:
+        mock_settings.return_value = Mock(project_id="test-project", api_key="test-key")
+        
+        trace = Trace(response="test", span_id=123456789, function_uuid="test-func-uuid")
+        
+        # Try to annotate with no annotations
+        with pytest.raises(ValueError, match="At least one annotation must be provided"):
+            trace.annotate()
+
+
+def test_trace_assign_span_not_found():
+    """Test assign method when span is not found (lines 171-173)."""
+    with patch("lilypad.traces.get_settings") as mock_settings:
+        mock_settings.return_value = Mock(project_id="test-project", api_key="test-key")
+        
+        with patch("lilypad.traces.get_sync_client") as mock_client:
+            # Mock _get_span_uuid to return None
+            mock_paginated = PaginatedSpanPublic(items=[], limit=10, offset=0, total=0)
+            mock_client.return_value.projects.functions.spans.list_paginated.return_value = mock_paginated
+            
+            trace = Trace(response="test", span_id=123456789, function_uuid="test-func-uuid")
+            
+            # Force _get_span_uuid to return None
+            with patch.object(trace, "_get_span_uuid", return_value=None):
+                from lilypad.exceptions import SpanNotFoundError
+                
+                with pytest.raises(SpanNotFoundError, match="Cannot assign: span not found for function test-func-uuid"):
+                    trace.assign("test@example.com")
+
+
+@pytest.mark.asyncio
+async def test_async_trace_annotate_empty_annotations():
+    """Test NoOpAsyncTrace annotate method with empty annotations (lines 321-322)."""
+    from lilypad.traces import NoOpAsyncTrace
+    
+    async_trace = NoOpAsyncTrace(response="test")
+    
+    # Try to annotate with no annotations
+    with pytest.raises(ValueError, match="At least one annotation must be provided"):
+        await async_trace.annotate()
+
+
+def test_trace_fallback_execute_user_function_only():
+    """Test the fallback execute_user_function_only (line 1079)."""
+    # This tests the case when get_tracer_provider is not a TracerProvider
+    with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+        # Make get_tracer_provider return something that's not a TracerProvider
+        mock_get_tracer.return_value = object()
+        
+        # Define a simple function
+        @trace()
+        def simple_func(x: int) -> int:
+            return x * 2
+        
+        # Call the function - should use fallback path
+        result = simple_func(5)
+        assert result == 10
+
+
+def test_construct_trace_attributes():
+    """Test _construct_trace_attributes function to cover the for loop (lines 644-649)."""
+    from lilypad.traces import _construct_trace_attributes
+    from lilypad._utils.serializer_registry import SerializerMap
+    
+    # Test with normal serializable values
+    arg_types = {"x": "int", "y": "str", "z": "list"}
+    arg_values = {"x": 42, "y": "hello", "z": [1, 2, 3]}
+    serializers = SerializerMap()
+    
+    result = _construct_trace_attributes("trace", arg_types, arg_values, serializers)
+    
+    # Check the result structure
+    assert "lilypad.trace.arg_types" in result
+    assert "lilypad.trace.arg_values" in result
+    
+    # Verify the values were serialized
+    import json
+    arg_values_json = json.loads(result["lilypad.trace.arg_values"])
+    assert arg_values_json["x"] == 42
+    assert arg_values_json["y"] == "hello"
+    assert arg_values_json["z"] == "[1,2,3]"  # Lists are serialized as JSON strings
+
+
+def test_construct_trace_attributes_with_exception():
+    """Test _construct_trace_attributes with values that cause serialization errors."""
+    from lilypad.traces import _construct_trace_attributes
+    from lilypad._utils.serializer_registry import SerializerMap
+    
+    # Create an object that will fail JSON serialization
+    class UnserializableObject:
+        def __init__(self):
+            self.circular_ref = self
+    
+    # Mock fast_jsonable to raise an exception for our unserializable object
+    with patch("lilypad.traces.fast_jsonable") as mock_fast_jsonable:
+        def side_effect(value, custom_serializers):
+            if isinstance(value, UnserializableObject):
+                raise ValueError("Cannot serialize circular reference")
+            # For other values, use the real json_dumps
+            from lilypad._utils.json import json_dumps
+            return json_dumps(value)
+        
+        mock_fast_jsonable.side_effect = side_effect
+        
+        arg_types = {"good": "str", "bad": "object"}
+        arg_values = {"good": "hello", "bad": UnserializableObject()}
+        serializers = SerializerMap()
+        
+        result = _construct_trace_attributes("trace", arg_types, arg_values, serializers)
+        
+        # Check the result
+        import json
+        arg_values_json = json.loads(result["lilypad.trace.arg_values"])
+        assert arg_values_json["good"] == '"hello"'  # Strings are also JSON-serialized
+        assert arg_values_json["bad"] == "could not serialize"
 
 
 # =============================================================================
@@ -2249,3 +2376,120 @@ async def test_async_trace_without_configuration():
             result2 = await async_func_wrap(10)
             assert isinstance(result2, NoOpAsyncTrace)
             assert result2.response == 30
+
+
+@pytest.mark.asyncio 
+async def test_trace_async_versioning_manual_and_wrap_mode():
+    """Test async trace with manual versioning and wrap mode (lines 955-988)."""
+    from lilypad.traces import trace, AsyncTrace
+    from opentelemetry.sdk.trace import TracerProvider
+    from uuid import uuid4
+    from contextlib import contextmanager
+    
+    # Create test functions with manual versioning
+    @trace(versioning="manual", mode="wrap")
+    async def async_func_manual_wrap(x: int) -> int:
+        return x * 3
+    
+    @trace(versioning="manual", mode="flow")  
+    async def async_func_manual_flow(x: int) -> int:
+        return x * 4
+    
+    # Mock settings to have valid project_id
+    mock_settings = Mock()
+    mock_settings.api_key = "test-key"
+    mock_settings.project_id = uuid4()
+    
+    # Mock async client
+    mock_client = AsyncMock()
+    
+    # Ensure tracer provider is valid
+    provider = TracerProvider()
+    
+    with (
+        patch("lilypad.traces.get_settings", return_value=mock_settings),
+        patch("lilypad.traces.get_async_client", return_value=mock_client),
+        patch("lilypad.traces.get_tracer_provider", return_value=provider),
+        patch("lilypad.spans.get_tracer") as mock_get_tracer,
+        patch("lilypad.traces.Closure") as mock_closure_class,
+        patch("lilypad.traces._construct_trace_attributes") as mock_construct_trace_attributes,
+        patch("lilypad.traces._set_span_attributes") as mock_set_span_attributes,
+        patch("lilypad.traces._set_trace_context") as mock_set_trace_context,
+    ):
+        # Set up mock tracer and span
+        mock_span = Mock()
+        mock_span.is_noop = False
+        mock_span.span_id = 123456789
+        mock_span.opentelemetry_span = Mock()
+        
+        mock_tracer = Mock()
+        mock_tracer.start_span.return_value = mock_span
+        mock_get_tracer.return_value = mock_tracer
+        
+        # Mock the Span context manager
+        original_span_class = trace.__globals__["Span"]
+        
+        class MockSpan:
+            def __init__(self, name):
+                self.name = name
+                self.is_noop = False
+                self.span_id = 123456789
+                self.opentelemetry_span = mock_span
+                self._span = mock_span
+                
+            def __enter__(self):
+                return self
+                
+            def __exit__(self, *args):
+                pass
+                
+            async def __aenter__(self):
+                return self
+                
+            async def __aexit__(self, *args):
+                pass
+        
+        # Mock Closure.from_fn
+        mock_closure = Mock()
+        mock_closure.hash = "test-hash"
+        mock_closure.code = "test-code"
+        mock_closure.name = "test-func"
+        mock_closure.signature = "test-signature"
+        mock_closure.dependencies = []
+        mock_closure_class.from_fn.return_value = mock_closure
+        
+        # Mock _construct_trace_attributes to return proper attributes
+        mock_construct_trace_attributes.return_value = {
+            "lilypad.trace.arg_types": "{}",
+            "lilypad.trace.arg_values": "{}"
+        }
+        
+        # Mock _set_span_attributes as a context manager
+        @contextmanager
+        def mock_span_attributes_cm(*args, **kwargs):
+            result_holder = Mock()
+            yield result_holder
+            
+        mock_set_span_attributes.side_effect = mock_span_attributes_cm
+        
+        with patch("lilypad.traces.Span", MockSpan):
+            # Test wrap mode with manual versioning - should return AsyncTrace
+            result = await async_func_manual_wrap(5)
+            assert isinstance(result, AsyncTrace)
+            assert result.response == 15
+            from opentelemetry.trace import format_span_id
+            assert result.formated_span_id == format_span_id(123456789)
+            assert result.function_uuid is None  # Manual versioning sets function to None
+            
+            # Verify _set_trace_context was called
+            mock_set_trace_context.assert_called_with({"span_id": 123456789, "function_uuid": None})
+            
+            # Reset mock for next test
+            mock_set_trace_context.reset_mock()
+            
+            # Test flow mode with manual versioning - should return the output directly  
+            result2 = await async_func_manual_flow(5)
+            assert result2 == 20
+            
+            # Verify _set_trace_context was called again
+            mock_set_trace_context.assert_called_with({"span_id": 123456789, "function_uuid": None})

--- a/sdks/python/tests/test_traces.py
+++ b/sdks/python/tests/test_traces.py
@@ -478,7 +478,7 @@ def test_trace_with_wrap_mode():
         mock_settings.return_value = Mock(project_id="test-project", api_key="test-key")
 
         with patch("lilypad.traces.get_sync_client") as mock_client, patch("lilypad.traces.Span") as mock_span_class:
-            mock_span = Mock(span_id=12345, opentelemetry_span=Mock())
+            mock_span = Mock(span_id=12345, opentelemetry_span=Mock(), is_noop=False)
             mock_span_context = Mock()
             mock_span_context.__enter__ = Mock(return_value=mock_span)
             mock_span_context.__exit__ = Mock(return_value=None)
@@ -486,12 +486,18 @@ def test_trace_with_wrap_mode():
 
             # Mock other required functions
             with mock_trace_decorator_context():
-                # Apply decorator after mocks are set up
-                @trace(mode="wrap")
-                def wrapped_func():
-                    return "wrapped"
+                # Mock get_tracer_provider to return a TracerProvider
+                from opentelemetry.sdk.trace import TracerProvider
 
-                result = wrapped_func()
+                with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+                    mock_get_tracer.return_value = TracerProvider()
+
+                    # Apply decorator after mocks are set up
+                    @trace(mode="wrap")
+                    def wrapped_func():
+                        return "wrapped"
+
+                    result = wrapped_func()
 
             # In wrap mode, should return Trace object
             assert isinstance(result, Trace)
@@ -536,7 +542,7 @@ def test_trace_with_mirascope():
                     mock_mirascope.side_effect = mock_middleware
 
                     with patch("lilypad.traces.Span") as mock_span_class:
-                        mock_span = Mock(span_id=12345, opentelemetry_span=Mock())
+                        mock_span = Mock(span_id=12345, opentelemetry_span=Mock(), is_noop=False)
                         mock_span_context = Mock()
                         mock_span_context.__enter__ = Mock(return_value=mock_span)
                         mock_span_context.__exit__ = Mock(return_value=None)
@@ -544,20 +550,26 @@ def test_trace_with_mirascope():
 
                         # Mock get_qualified_name
                         with mock_trace_decorator_context():
-                            # Create function with mirascope attributes first
-                            def mirascope_func():
-                                return "mirascope"
+                            # Mock get_tracer_provider to return a TracerProvider
+                            from opentelemetry.sdk.trace import TracerProvider
 
-                            # Add mirascope attributes before decoration
-                            mirascope_func.__mirascope_call__ = True
-                            mirascope_func._prompt_template = "Test prompt"
+                            with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+                                mock_get_tracer.return_value = TracerProvider()
 
-                            # Apply decorator after attributes are set
-                            decorated_func = trace(versioning="automatic")(mirascope_func)
+                                # Create function with mirascope attributes first
+                                def mirascope_func():
+                                    return "mirascope"
 
-                            # Test that the function still returns its original result
-                            # The middleware is applied but we're testing the decorator itself
-                            result = decorated_func()
+                                # Add mirascope attributes before decoration
+                                mirascope_func.__mirascope_call__ = True
+                                mirascope_func._prompt_template = "Test prompt"
+
+                                # Apply decorator after attributes are set
+                                decorated_func = trace(versioning="automatic")(mirascope_func)
+
+                                # Test that the function still returns its original result
+                                # The middleware is applied but we're testing the decorator itself
+                                result = decorated_func()
                             assert result == "mirascope"
 
                             # Verify mirascope middleware was called
@@ -570,7 +582,7 @@ def test_trace_with_tags():
         mock_settings.return_value = Mock(project_id="test-project", api_key="test-key")
 
         with patch("lilypad.traces.get_sync_client") as mock_client, patch("lilypad.traces.Span") as mock_span_class:
-            mock_span = Mock(span_id=12345, opentelemetry_span=Mock())
+            mock_span = Mock(span_id=12345, opentelemetry_span=Mock(), is_noop=False)
             mock_span_context = Mock()
             mock_span_context.__enter__ = Mock(return_value=mock_span)
             mock_span_context.__exit__ = Mock(return_value=None)
@@ -584,12 +596,18 @@ def test_trace_with_tags():
 
                 # Mock other required functions
                 with mock_trace_decorator_context():
-                    # Apply decorator after mocks are set up
-                    @trace(tags=["tag1", "tag2"])
-                    def tagged_func():
-                        return "tagged"
+                    # Mock get_tracer_provider to return a TracerProvider
+                    from opentelemetry.sdk.trace import TracerProvider
 
-                    result = tagged_func()
+                    with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+                        mock_get_tracer.return_value = TracerProvider()
+
+                        # Apply decorator after mocks are set up
+                        @trace(tags=["tag1", "tag2"])
+                        def tagged_func():
+                            return "tagged"
+
+                        result = tagged_func()
                 assert result == "tagged"
 
                 # Check tags were passed
@@ -875,14 +893,20 @@ def test_trace_fallback_on_error():
                         )
                         mock_closure_class.from_fn.return_value = mock_closure
 
-                        # Apply decorator after mock is set up
-                        @trace(versioning="automatic")
-                        def fallback_func(x: int) -> int:
-                            return x + 1000
+                        # Mock get_tracer_provider to return a TracerProvider
+                        from opentelemetry.sdk.trace import TracerProvider
 
-                        # Function should raise error when registration fails
-                        with pytest.raises(Exception, match="Registration failed"):
-                            result = fallback_func(1)
+                        with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+                            mock_get_tracer.return_value = TracerProvider()
+
+                            # Apply decorator after mock is set up
+                            @trace(versioning="automatic")
+                            def fallback_func(x: int) -> int:
+                                return x + 1000
+
+                            # Function should raise error when registration fails
+                            with pytest.raises(Exception, match="Registration failed"):
+                                result = fallback_func(1)
 
 
 @pytest.mark.asyncio
@@ -915,14 +939,20 @@ async def test_async_trace_fallback():
                         )
                         mock_closure_class.from_fn.return_value = mock_closure
 
-                        # Apply decorator after mock is set up
-                        @trace(versioning="automatic")
-                        async def async_fallback_func(x: int) -> int:
-                            return x + 2000
+                        # Mock get_tracer_provider to return a TracerProvider
+                        from opentelemetry.sdk.trace import TracerProvider
 
-                        # Function should raise error when registration fails
-                        with pytest.raises(Exception, match="Async registration failed"):
-                            result = await async_fallback_func(1)
+                        with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+                            mock_get_tracer.return_value = TracerProvider()
+
+                            # Apply decorator after mock is set up
+                            @trace(versioning="automatic")
+                            async def async_fallback_func(x: int) -> int:
+                                return x + 2000
+
+                            # Function should raise error when registration fails
+                            with pytest.raises(Exception, match="Async registration failed"):
+                                result = await async_fallback_func(1)
 
 
 def test_trace_with_trace_ctx_parameter():
@@ -965,15 +995,21 @@ def test_trace_with_trace_ctx_parameter():
                         )
                         mock_closure_class.from_fn.return_value = mock_closure
 
-                        # Apply decorator after mocks are set up
-                        @trace()
-                        def func_with_trace_ctx(trace_ctx, x: int) -> int:
-                            # trace_ctx is first parameter, x is second
-                            return x * 2
+                        # Mock get_tracer_provider to return a TracerProvider
+                        from opentelemetry.sdk.trace import TracerProvider
 
-                        # Call without trace_ctx - decorator will pass span as first arg
-                        result = func_with_trace_ctx(5)
-                        assert result == 10
+                        with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+                            mock_get_tracer.return_value = TracerProvider()
+
+                            # Apply decorator after mocks are set up
+                            @trace()
+                            def func_with_trace_ctx(trace_ctx, x: int) -> int:
+                                # trace_ctx is first parameter, x is second
+                                return x * 2
+
+                            # Call without trace_ctx - decorator will pass span as first arg
+                            result = func_with_trace_ctx(5)
+                            assert result == 10
 
                         # Call with explicit trace_ctx - normal call
                         result = func_with_trace_ctx(Mock(), 5)
@@ -1049,13 +1085,19 @@ def test_function_creation_when_not_found():
                         mock_span_context.__exit__ = Mock(return_value=None)
                         mock_span_class.return_value = mock_span_context
 
-                        # Apply decorator after mocks are set up
-                        @trace(versioning="automatic")
-                        def new_func():
-                            return "new"
+                        # Mock get_tracer_provider to return a TracerProvider
+                        from opentelemetry.sdk.trace import TracerProvider
 
-                        result = new_func()
-                        assert result == "new"
+                        with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+                            mock_get_tracer.return_value = TracerProvider()
+
+                            # Apply decorator after mocks are set up
+                            @trace(versioning="automatic")
+                            def new_func():
+                                return "new"
+
+                            result = new_func()
+                            assert result == "new"
 
                         # Verify function was created
                         mock_lilypad.projects.functions.create.assert_called_once()
@@ -1139,18 +1181,26 @@ def format_span_id(span_id: int) -> str:
 
 def test_trace_annotate_no_annotations():
     """Test trace.annotate with no annotations - covers line 141."""
+    from opentelemetry.sdk.trace import TracerProvider
+
     with patch("lilypad.traces.get_settings") as mock_settings, patch("lilypad.traces.get_sync_client") as mock_client:
-        # Create a trace instance with wrap mode to get Trace object
-        @trace(mode="wrap")
-        def test_func():
-            return "result"
+        mock_settings.return_value = Mock(project_id="test-project", api_key="test-key")
 
-        # Call the function to get a trace
-        result = test_func()
+        # Mock get_tracer_provider to return a TracerProvider
+        with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+            mock_get_tracer.return_value = TracerProvider()
 
-        # Try to annotate with no annotations
-        with pytest.raises(ValueError, match="At least one annotation must be provided"):
-            result.annotate()
+            # Create a trace instance with wrap mode to get Trace object
+            @trace(mode="wrap")
+            def test_func():
+                return "result"
+
+            # Call the function to get a trace
+            result = test_func()
+
+            # Try to annotate with no annotations
+            with pytest.raises(ValueError, match="At least one annotation must be provided"):
+                result.annotate()
 
 
 def test_trace_automatic_versioning_with_recording_enabled():
@@ -1318,17 +1368,23 @@ def test_trace_assign_span_not_found():
         client_instance.projects.functions.spans.list_paginated.return_value = mock_response
         mock_client.return_value = client_instance
 
-        # Create a trace instance with wrap mode to get Trace object
-        @trace(mode="wrap")
-        def test_func():
-            return "result"
+        # Mock get_tracer_provider to return a TracerProvider
+        from opentelemetry.sdk.trace import TracerProvider
 
-        # Call the function to get a trace
-        result = test_func()
+        with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+            mock_get_tracer.return_value = TracerProvider()
 
-        # Try to assign when span is not found
-        with pytest.raises(SpanNotFoundError, match="Cannot assign: span not found"):
-            result.assign("test@example.com")
+            # Create a trace instance with wrap mode to get Trace object
+            @trace(mode="wrap")
+            def test_func():
+                return "result"
+
+            # Call the function to get a trace
+            result = test_func()
+
+            # Try to assign when span is not found
+            with pytest.raises(SpanNotFoundError, match="Cannot assign: span not found"):
+                result.assign("test@example.com")
 
 
 # =============================================================================
@@ -1791,16 +1847,22 @@ async def test_async_trace_with_trace_ctx_parameter():
         with patch("lilypad.traces.get_async_client") as mock_client:
             mock_client.return_value = Mock()
 
-            # Create function that expects trace_ctx
-            @trace()
-            async def test_func(trace_ctx: Span, x: int) -> int:
-                # Verify trace_ctx is a Span
-                assert hasattr(trace_ctx, "opentelemetry_span")
-                return x * 2
+            # Mock get_tracer_provider to return a TracerProvider
+            from opentelemetry.sdk.trace import TracerProvider
 
-            # Call without providing trace_ctx - it should be injected
-            result = await test_func(5)
-            assert result == 10
+            with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+                mock_get_tracer.return_value = TracerProvider()
+
+                # Create function that expects trace_ctx
+                @trace()
+                async def test_func(trace_ctx: Span, x: int) -> int:
+                    # Verify trace_ctx is a Span
+                    assert hasattr(trace_ctx, "opentelemetry_span")
+                    return x * 2
+
+                # Call without providing trace_ctx - it should be injected
+                result = await test_func(5)
+                assert result == 10
 
 
 # =============================================================================
@@ -1817,17 +1879,23 @@ async def test_async_trace_wrap_mode_return():
         with patch("lilypad.traces.get_async_client") as mock_client:
             mock_client.return_value = Mock()
 
-            # Create function with wrap mode
-            @trace(mode="wrap")
-            async def test_func(x: int) -> int:
-                return x * 3
+            # Mock get_tracer_provider to return a TracerProvider
+            from opentelemetry.sdk.trace import TracerProvider
 
-            # Call function
-            result = await test_func(5)
+            with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+                mock_get_tracer.return_value = TracerProvider()
 
-            # Should return AsyncTrace
-            assert isinstance(result, AsyncTrace)
-            assert result.response == 15
+                # Create function with wrap mode
+                @trace(mode="wrap")
+                async def test_func(x: int) -> int:
+                    return x * 3
+
+                # Call function
+                result = await test_func(5)
+
+                # Should return AsyncTrace
+                assert isinstance(result, AsyncTrace)
+                assert result.response == 15
 
 
 # =============================================================================
@@ -2116,3 +2184,64 @@ def test_protocol_ellipsis_evaluation():
     with contextlib.suppress(Exception):
         wrapped_versioned_call = WrappedVersionedFunctionTraceDecorator.__call__
         assert wrapped_versioned_call is not None
+
+
+def test_trace_without_configuration():
+    """Test @trace decorator when lilypad is not configured."""
+    from lilypad.traces import trace, NoOpTrace
+
+    @trace()
+    def sync_func(x: int) -> int:
+        return x * 2
+
+    @trace(mode="wrap")
+    def wrap_func(x: int) -> int:
+        return x * 3
+
+    # Mock get_tracer_provider to return non-TracerProvider
+    with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+        mock_get_tracer.return_value = Mock(spec=object)  # Not a TracerProvider
+
+        with (
+            patch("lilypad.traces._trace_warning_shown", False),
+            patch("lilypad.traces.logger.warning") as mock_warning,
+            mock_trace_decorator_context(),
+        ):
+            # Normal mode: returns raw result
+            result1 = sync_func(10)
+            assert result1 == 20
+
+            # Wrap mode: returns NoOpTrace
+            result2 = wrap_func(10)
+            assert isinstance(result2, NoOpTrace)
+            assert result2.response == 30
+
+            # Warning logged once
+            mock_warning.assert_called_once()
+            assert "Lilypad has not been configured" in mock_warning.call_args[0][0]
+
+
+@pytest.mark.asyncio
+async def test_async_trace_without_configuration():
+    """Test async @trace decorator when lilypad is not configured."""
+    from lilypad.traces import trace, NoOpAsyncTrace
+
+    @trace()
+    async def async_func_default(x: int) -> int:
+        return x * 2
+
+    @trace(mode="wrap")
+    async def async_func_wrap(x: int) -> int:
+        return x * 3
+
+    # Mock get_tracer_provider to return non-TracerProvider
+    with patch("lilypad.traces.get_tracer_provider") as mock_get_tracer:
+        mock_get_tracer.return_value = Mock(spec=object)  # Not a TracerProvider
+
+        with patch("lilypad.traces._trace_warning_shown", False), mock_trace_decorator_context():
+            result1 = await async_func_default(10)
+            assert result1 == 20
+
+            result2 = await async_func_wrap(10)
+            assert isinstance(result2, NoOpAsyncTrace)
+            assert result2.response == 30


### PR DESCRIPTION
Fixes: https://github.com/Mirascope/lilypad/issues/588