### PR TITLE
test: add OpenAI telemetry utility tests

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -30,16 +30,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-openai = [
-    "openai>=1.98.0",
-]
+openai = ["openai>=1.98.0"]
 
 [dependency-groups]
-dev = [
-    "pyright>=1.1.403",
-    "ruff>=0.12.7",
-    "pre-commit>=3.5.0",
-]
+dev = ["pyright>=1.1.403", "ruff>=0.12.7", "pre-commit>=3.5.0"]
 test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
@@ -49,9 +43,7 @@ test = [
     "inline-snapshot>=0.23.0",
     "python-dotenv>=1.1.1",
 ]
-examples = [
-    "openai>=1.98.0",
-]
+examples = ["openai>=1.98.0"]
 
 [build-system]
 requires = ["uv_build>=0.8.4,<0.9.0"]
@@ -166,16 +158,12 @@ include = ["src", "tests", "examples"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = [
-    "-v",
-]
+addopts = ["-v"]
 asyncio_mode = "auto"
-markers = [
-    "vcr: Mark test to use VCR.py for HTTP request recording/playback",
-]
+markers = ["vcr: Mark test to use VCR.py for HTTP request recording/playback"]
 
 [tool.coverage.run]
-branch = true
+branch = false
 source = ["src/lilypad"]
 
 [tool.coverage.report]
@@ -187,10 +175,6 @@ exclude_lines = [
     "pass",
     "except ImportError:",
 ]
-exclude_also = [
-    "@overload",
-    "@abstractmethod",
-    "if TYPE_CHECKING:",
-]
+exclude_also = ["@overload", "@abstractmethod", "if TYPE_CHECKING:"]
 precision = 2
 show_missing = true

--- a/sdks/python/src/lilypad/_internal/otel/utils.py
+++ b/sdks/python/src/lilypad/_internal/otel/utils.py
@@ -18,7 +18,6 @@
 from abc import ABC, abstractmethod
 from types import TracebackType
 from typing import Any, Generic, TypeVar, Protocol, TypedDict
-from urllib.parse import urlparse
 from collections.abc import Callable, Iterator, AsyncIterator
 
 from httpx import URL
@@ -38,7 +37,6 @@ class BaseMetadata(TypedDict, total=False):
 
     response_id: str | None
     response_model: str | None
-    finish_reasons: list[str]
     prompt_tokens: int | None
     completion_tokens: int | None
 
@@ -369,17 +367,11 @@ def set_server_address_and_port(
     """Extract and set server address and port attributes from client instance."""
     base_client = getattr(client, "_client", None)
     base_url = getattr(base_client, "base_url", None)
-    if not base_url:
+    if not isinstance(base_url, URL):
         return
 
-    port = -1
-    if isinstance(base_url, URL):
-        attributes[server_attributes.SERVER_ADDRESS] = base_url.host
-        port = base_url.port
-    elif isinstance(base_url, str):
-        url = urlparse(base_url)
-        attributes[server_attributes.SERVER_ADDRESS] = url.hostname
-        port = url.port
+    attributes[server_attributes.SERVER_ADDRESS] = base_url.host
+    port = base_url.port
 
     if port and port != 443 and port > 0:
         attributes[server_attributes.SERVER_PORT] = port

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_async_chat_completion_with_tools.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_async_chat_completion_with_tools.yaml
@@ -1,7 +1,10 @@
 interactions:
 - request:
-    body: '{"messages":[{"role":"system","content":"You are a helpful assistant who
-      speaks like a pirate."},{"role":"user","content":"What is the capital of France?"}],"model":"gpt-4o-mini","max_tokens":100,"temperature":0.7}'
+    body: "{\"messages\":[{\"role\":\"user\",\"content\":\"What's the weather in Tokyo
+      today?\"}],\"model\":\"gpt-4o-mini\",\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get
+      today's weather report\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"City
+      and country e.g. Bogot\xE1, Colombia\"},\"units\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"],\"description\":\"Units
+      the temperature will be returned in.\"}},\"required\":[\"location\",\"units\"],\"additionalProperties\":false}}}]}"
     headers:
       accept:
       - application/json
@@ -10,7 +13,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '214'
+      - '515'
       content-type:
       - application/json
       host:
@@ -40,15 +43,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jJLBbtswDIbvfgpGl13sIU0cNMmtWLFLNqAbdtg6FAYj0bY2WRIkZltQ
-        5N0H2Wnsbh2wiw78+FP8ST5mAEIrsQUhW2TZeVO8WX6+2xnu7m930qij/WDWcf7z/bsvH293RuRJ
-        4fbfSPKT6rV0nTfE2tkBy0DIlKpeXa/KzWpTLtc96Jwik2SN56J0RaetLhbzRVnMr4ur9VndOi0p
-        ii18zQAAHvs39WkV/RJbmOdPkY5ixIbE9pIEIIIzKSIwRh0ZLYt8hNJZJtu3fhNCyKFDpuMMPrUE
-        Er1mNOBqeBvQSoI9wR0GHWdwA01Aq0BqPoJ7BUY3LUdIoeC6lJyDZtjTbPpboPoQMTm2B2MmAK11
-        jGlivc+HMzldnBnX+OD28Q+pqLXVsa0CYXQ2uYjsvOjpKQN46Cd4eDYU4YPrPFfsvlP/3WIzlBPj
-        3iZwdYbsGM0YX5X5C9UqRYzaxMkGhETZkhqV47rwoLSbgGzi+e9mXqo9+Na2+Z/yI5CSPJOqfCCl
-        5XPDY1qgdNX/SrvMuG9YRAo/tKSKNYW0B0U1HsxwayIeI1NX1do2FHzQw8HVvlqWuCqRNkspslP2
-        GwAA//8DAMClSgZ+AwAA
+        H4sIAAAAAAAAAwAAAP//jFPLbtswELzrK4g924Wfca1renFswC1SoEXrQFhTK5kNRRJ8JDEM/3sh
+        yrZkJwWqg0DscGZnHzwkjIHIIWXAd+h5ZWT/fvxTLL7iYuteZz+Wdq7MOrzl+1WYfbt/gF7N0Ns/
+        xP2Z9YnrykjyQqsG5pbQU606nE0n87vB3XASgUrnJGtaaXx/ovuVUKI/Gowm/cGsP/x8Yu+04OQg
+        Zb8Txhg7xH/tU+X0Bikb9M6RipzDkiC9XGIMrJZ1BNA54TwqD70W5Fp5UrV1FaTsAF5rmXGUsk3c
+        fIfOuW0WSplNcf3yhS/C2m6Xj9VqtP31uHLlUnfyNdJ7Ew0VQfFLkzr4JZ7eJGMMFFaRW5LPXgn9
+        juwNnTFAW4aKlK+tw2EDUnOsBTeQbuC7ft7rHntAg2oDvQ0EJbyLECfpRHAbOMKV5DH56PzU6Zal
+        IjiU79uISmkfk8c+Pp2Q42VkUpfG6q27oUIhlHC7zBK62InuQJKzkWgBwtXMwVhdGZ95/Uwx6Wze
+        iEK7li04Gp5Arz3KNj4cnLbqWi7LyaOIO3FZQ458R3lLbdcRQy50B0g6pb9385F2U75Q5f/ItwDn
+        ZDzlmbGUC35dcXvNUv1q/3Xt0uRoGBzZF8Ep84JsPY6cCgyyeUvg9s5TlRVClWSNFfFBQWGy8QSn
+        E6T5mENyTP4CAAD//wMAq0tUt14EAAA=
     headers:
       Connection:
       - keep-alive
@@ -57,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Aug 2025 00:43:59 GMT
+      - Tue, 12 Aug 2025 01:03:35 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -73,11 +77,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '1026'
+      - '1170'
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1233'
+      - '1187'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -85,7 +89,7 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '3999976'
+      - '3999988'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_async_chat_completion_with_tools_pydantic.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_async_chat_completion_with_tools_pydantic.yaml
@@ -1,7 +1,10 @@
 interactions:
 - request:
-    body: '{"messages":[{"role":"system","content":"You are a helpful assistant who
-      speaks like a pirate."},{"role":"user","content":"What is the capital of France?"}],"model":"gpt-4o-mini","max_tokens":100,"temperature":0.7}'
+    body: "{\"messages\":[{\"role\":\"user\",\"content\":\"What's the weather in Tokyo
+      today?\"}],\"model\":\"gpt-4o-mini\",\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get
+      today's weather report\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"City
+      and country e.g. Bogot\xE1, Colombia\"},\"units\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"],\"description\":\"Units
+      the temperature will be returned in.\"}},\"required\":[\"location\",\"units\"],\"additionalProperties\":false}}}]}"
     headers:
       accept:
       - application/json
@@ -10,7 +13,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '214'
+      - '515'
       content-type:
       - application/json
       host:
@@ -34,21 +37,22 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.13.2
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jJLBbtswDIbvfgpGl13sIU0cNMmtWLFLNqAbdtg6FAYj0bY2WRIkZltQ
-        5N0H2Wnsbh2wiw78+FP8ST5mAEIrsQUhW2TZeVO8WX6+2xnu7m930qij/WDWcf7z/bsvH293RuRJ
-        4fbfSPKT6rV0nTfE2tkBy0DIlKpeXa/KzWpTLtc96Jwik2SN56J0RaetLhbzRVnMr4ur9VndOi0p
-        ii18zQAAHvs39WkV/RJbmOdPkY5ixIbE9pIEIIIzKSIwRh0ZLYt8hNJZJtu3fhNCyKFDpuMMPrUE
-        Er1mNOBqeBvQSoI9wR0GHWdwA01Aq0BqPoJ7BUY3LUdIoeC6lJyDZtjTbPpboPoQMTm2B2MmAK11
-        jGlivc+HMzldnBnX+OD28Q+pqLXVsa0CYXQ2uYjsvOjpKQN46Cd4eDYU4YPrPFfsvlP/3WIzlBPj
-        3iZwdYbsGM0YX5X5C9UqRYzaxMkGhETZkhqV47rwoLSbgGzi+e9mXqo9+Na2+Z/yI5CSPJOqfCCl
-        5XPDY1qgdNX/SrvMuG9YRAo/tKSKNYW0B0U1HsxwayIeI1NX1do2FHzQw8HVvlqWuCqRNkspslP2
-        GwAA//8DAMClSgZ+AwAA
+        H4sIAAAAAAAAAwAAAP//jFNda9swFH33rxD3OR5O4pLEb21H2cZgtCvZYC5Gka9tJbIkJHlrFvLf
+        i+XUdtIO5gcj7tE599wPHQJCgOeQEGAVdazWIrydY2Q393cP35Zseb1ef48XH3/sfoq/D59uIpi0
+        DLXZInOvrA9M1Vqg40p2MDNIHbaq08VVvFrGy3nkgVrlKFpaqV0Yq7DmkoezaBaH0SKcLk/sSnGG
+        FhLyKyCEkIP/tz5ljs+QEK/lIzVaS0uEpL9ECBgl2ghQa7l1VDqYDCBT0qFsrctGiBHglBIZo0IM
+        ibvvMDoPzaJCZBXd3s3v49t8PXu+duzrbn/zeRvj4yhfJ73X3lDRSNY3aYT38eQiGSEgae25Jbrs
+        D1JXobmgEwLUlE2N0rXW4ZCCUIy2gikkKTyq3V5NyBeqqUxhkkIjubMeYigsb2wKRziTPAbvnZ9G
+        3TJYNJaKt22kUirnk/s+Pp2QYz8yoUpt1MZeUKHgktsqM0it78R4IMGrEW8BmrOZgzaq1i5zaoc+
+        6WLVicKwlgM4m55ApxwVQ3wanbbqXC7L0VHud6JfQ0ZZhflAHdaRNjlXIyAYlf7WzXvaXflclv8j
+        PwCMoXaYZ9pgztl5xcM1g+2r/de1vsneMFg0vznDzHE07ThyLGgjurcEdm8d1lnBZYlGG+4fFBQ6
+        m8f0Kqa4mjMIjsELAAAA//8DAPEHtwteBAAA
     headers:
       Connection:
       - keep-alive
@@ -57,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Aug 2025 00:43:59 GMT
+      - Tue, 12 Aug 2025 07:47:10 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -73,11 +77,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '1026'
+      - '571'
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1233'
+      - '597'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -85,7 +89,7 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '3999976'
+      - '3999989'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_async_streaming_chat_completion_with_tools.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_async_streaming_chat_completion_with_tools.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: "{\"messages\":[{\"role\":\"user\",\"content\":\"What's the weather in Tokyo
+      today?\"}],\"model\":\"gpt-4o-mini\",\"stream\":true,\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get
+      today's weather report\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"City
+      and country e.g. Bogot\xE1, Colombia\"},\"units\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"],\"description\":\"Units
+      the temperature will be returned in.\"}},\"required\":[\"location\",\"units\"],\"additionalProperties\":false}}}]}"
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '529'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 1.98.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.98.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_XVTodORgp6JgvYpfH5bes8Qe","type":"function","function":{"name":"get_weather","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"c"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"TA04BAPqLtb"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"location"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"YTzOGj"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"uQsPB5Gfo"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Tokyo"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Aw3wYieFp"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":","}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"FbFR8eAVOCavd"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        Japan"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"wagpnSfc"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Gt9mSzCSD"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"units"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"z2n1eGoFd"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"tGUKUTX4S"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"c"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"AVzIapZ5RXVqR"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"elsius"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"0MfZjDGZ"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"t2XeNemXYO0"}
+
+
+        data: {"id":"chatcmpl-C3ZNov4ucG2TIyw9QYjoNz0o0elhb","object":"chat.completion.chunk","created":1754967032,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"kvOCGwEEIe4V"}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 12 Aug 2025 02:50:32 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-processing-ms:
+      - '353'
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '398'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999989'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_async_streaming_with_usage.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_async_streaming_with_usage.yaml
@@ -1,0 +1,174 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Say goodbye"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '130'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 1.98.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.98.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"gZizkhHK6"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"Good"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"In9g3Py"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"bye"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"pXy1Ud2P"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"YD4NwYCbDW"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        If"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"oVKSE3RJ"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        you"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Hx8yhCY"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        ever"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"XBJL2Z"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        need"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"8ybvVC"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        anything"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"bz"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        in"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"hJ4VPvaY"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"rcUrR80"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        future"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"alVV"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"6eRa1C8H33"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        feel"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"PHoiWv"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        free"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"tHCxxG"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        to"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"EupPwuZk"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        reach"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Urs2d"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        out"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"bHIIJYd"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"IfdKNoBWZV"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        Take"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"Ueat4h"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        care"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"SGUcnS"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"iosvjiXrMM"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"4oPNX"}
+
+
+        data: {"id":"chatcmpl-C3dq3nmP2yy0NQsNHg85hoaoMpNrh","object":"chat.completion.chunk","created":1754984159,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[],"usage":{"prompt_tokens":9,"completion_tokens":21,"total_tokens":30,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"4Kbx2Dh8M98"}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 12 Aug 2025 07:36:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-processing-ms:
+      - '285'
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '571'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999995'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_message_with_non_string_content.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_message_with_non_string_content.yaml
@@ -1,0 +1,163 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"What''s in
+      this image?"},{"type":"image_url","image_url":{"url":"https://example.com/image.jpg","detail":"high"}}]}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '200'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.98.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.98.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n  \"error\": {\n    \"message\": \"Error while downloading https://example.com/image.jpg.\",\n
+        \   \"type\": \"invalid_request_error\",\n    \"param\": null,\n    \"code\":
+        \"invalid_image_url\"\n  }\n}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '181'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 12 Aug 2025 08:12:31 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-processing-ms:
+      - '321'
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '338'
+      x-ratelimit-limit-input-images:
+      - '50000'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-input-images:
+      - '49999'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999227'
+      x-ratelimit-reset-input-images:
+      - 1ms
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 11ms
+    status:
+      code: 400
+      message: Bad Request
+- request:
+    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Describe
+      this data"},{"type":"text","text":"The data is: [1, 2, 3]"}]}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '156'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.98.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.98.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: "{\n    \"error\": {\n        \"message\": \"Incorrect API key provided:
+        test-api-key. You can find your API key at https://platform.openai.com/account/api-keys.\",\n
+        \       \"type\": \"invalid_request_error\",\n        \"param\": null,\n        \"code\":
+        \"invalid_api_key\"\n    }\n}\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '262'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 12 Aug 2025 08:13:37 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      vary:
+      - Origin
+      x-envoy-upstream-service-time:
+      - '2'
+    status:
+      code: 401
+      message: Unauthorized
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_sync_chat_completion_with_tools.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_sync_chat_completion_with_tools.yaml
@@ -1,7 +1,10 @@
 interactions:
 - request:
-    body: '{"messages":[{"role":"system","content":"You are a helpful assistant who
-      speaks like a pirate."},{"role":"user","content":"What is the capital of France?"}],"model":"gpt-4o-mini","max_tokens":100,"temperature":0.7}'
+    body: "{\"messages\":[{\"role\":\"user\",\"content\":\"What's the weather in Tokyo
+      today?\"}],\"model\":\"gpt-4o-mini\",\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get
+      today's weather report\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"City
+      and country e.g. Bogot\xE1, Colombia\"},\"units\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"],\"description\":\"Units
+      the temperature will be returned in.\"}},\"required\":[\"location\",\"units\"],\"additionalProperties\":false}}}]}"
     headers:
       accept:
       - application/json
@@ -10,17 +13,17 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '214'
+      - '515'
       content-type:
       - application/json
       host:
       - api.openai.com
       user-agent:
-      - AsyncOpenAI/Python 1.98.0
+      - OpenAI/Python 1.98.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
-      - async:asyncio
+      - 'false'
       x-stainless-lang:
       - python
       x-stainless-os:
@@ -40,15 +43,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jJLBbtswDIbvfgpGl13sIU0cNMmtWLFLNqAbdtg6FAYj0bY2WRIkZltQ
-        5N0H2Wnsbh2wiw78+FP8ST5mAEIrsQUhW2TZeVO8WX6+2xnu7m930qij/WDWcf7z/bsvH293RuRJ
-        4fbfSPKT6rV0nTfE2tkBy0DIlKpeXa/KzWpTLtc96Jwik2SN56J0RaetLhbzRVnMr4ur9VndOi0p
-        ii18zQAAHvs39WkV/RJbmOdPkY5ixIbE9pIEIIIzKSIwRh0ZLYt8hNJZJtu3fhNCyKFDpuMMPrUE
-        Er1mNOBqeBvQSoI9wR0GHWdwA01Aq0BqPoJ7BUY3LUdIoeC6lJyDZtjTbPpboPoQMTm2B2MmAK11
-        jGlivc+HMzldnBnX+OD28Q+pqLXVsa0CYXQ2uYjsvOjpKQN46Cd4eDYU4YPrPFfsvlP/3WIzlBPj
-        3iZwdYbsGM0YX5X5C9UqRYzaxMkGhETZkhqV47rwoLSbgGzi+e9mXqo9+Na2+Z/yI5CSPJOqfCCl
-        5XPDY1qgdNX/SrvMuG9YRAo/tKSKNYW0B0U1HsxwayIeI1NX1do2FHzQw8HVvlqWuCqRNkspslP2
-        GwAA//8DAMClSgZ+AwAA
+        H4sIAAAAAAAAAwAAAP//jFPLbtswELzrK4g9W4VfqmPdDB+KtECbNO7DrQKBoVYSY4pkSKqNa/jf
+        C9G2JDspUB0EYoczO/vgLiAEeAYxAVZSxyotwuXke/nxQ1Gtlp+j8m64vBPR02LF/9zeXM3WMGgY
+        6uERmTux3jBVaYGOK3mAmUHqsFEdzaLp/O0wimYeqFSGoqEV2oVTFVZc8nA8HE/D4SwcXR3ZpeIM
+        LcTkZ0AIITv/b3zKDJ8hJsPBKVKhtbRAiNtLhIBRookAtZZbR6WDQQcyJR3KxrqshegBTimRMipE
+        l/jw7XrnrllUiPTW5k9fs8Xi+t2jXlTffnzarN3Nl+t1L99Bequ9obyWrG1SD2/j8UUyQkDSynML
+        dOlvpK5Ec0EnBKgp6gqla6zDLgGhGG0EE4gTWKnNVg3Ie6qpTGCQQC25sx5iKCyvbQJ7OJPcB6+d
+        73vdMpjXloqXbaRSKueT+z7eH5F9OzKhCm3Ug72gQs4lt2VqkFrfif5AgpMRbwHqs5mDNqrSLnVq
+        gz7pbH4QhW4tO3A8OoJOOSq6+Gh43KpzuTRDR7nfiXYNGWUlZh21W0daZ1z1gKBX+ks3r2kfyuey
+        +B/5DmAMtcMs1QYzzs4r7q4ZbF7tv661TfaGwaL5xRmmjqNpxpFhTmtxeEtgt9ZhleZcFmi04f5B
+        Qa7TyZRGU4rzCYNgH/wFAAD//wMAwzZf514EAAA=
     headers:
       Connection:
       - keep-alive
@@ -57,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Aug 2025 00:43:59 GMT
+      - Tue, 12 Aug 2025 01:02:37 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -73,11 +77,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '1026'
+      - '537'
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1233'
+      - '661'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -85,7 +89,7 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '3999976'
+      - '3999989'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_sync_chat_completion_with_tools_pydantic.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_sync_chat_completion_with_tools_pydantic.yaml
@@ -1,7 +1,10 @@
 interactions:
 - request:
-    body: '{"messages":[{"role":"system","content":"You are a helpful assistant who
-      speaks like a pirate."},{"role":"user","content":"What is the capital of France?"}],"model":"gpt-4o-mini","max_tokens":100,"temperature":0.7}'
+    body: "{\"messages\":[{\"role\":\"user\",\"content\":\"What's the weather in Tokyo
+      today?\"}],\"model\":\"gpt-4o-mini\",\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get
+      today's weather report\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"City
+      and country e.g. Bogot\xE1, Colombia\"},\"units\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"],\"description\":\"Units
+      the temperature will be returned in.\"}},\"required\":[\"location\",\"units\"],\"additionalProperties\":false}}}]}"
     headers:
       accept:
       - application/json
@@ -10,17 +13,17 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '214'
+      - '515'
       content-type:
       - application/json
       host:
       - api.openai.com
       user-agent:
-      - AsyncOpenAI/Python 1.98.0
+      - OpenAI/Python 1.98.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
-      - async:asyncio
+      - 'false'
       x-stainless-lang:
       - python
       x-stainless-os:
@@ -34,21 +37,22 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.13.2
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jJLBbtswDIbvfgpGl13sIU0cNMmtWLFLNqAbdtg6FAYj0bY2WRIkZltQ
-        5N0H2Wnsbh2wiw78+FP8ST5mAEIrsQUhW2TZeVO8WX6+2xnu7m930qij/WDWcf7z/bsvH293RuRJ
-        4fbfSPKT6rV0nTfE2tkBy0DIlKpeXa/KzWpTLtc96Jwik2SN56J0RaetLhbzRVnMr4ur9VndOi0p
-        ii18zQAAHvs39WkV/RJbmOdPkY5ixIbE9pIEIIIzKSIwRh0ZLYt8hNJZJtu3fhNCyKFDpuMMPrUE
-        Er1mNOBqeBvQSoI9wR0GHWdwA01Aq0BqPoJ7BUY3LUdIoeC6lJyDZtjTbPpboPoQMTm2B2MmAK11
-        jGlivc+HMzldnBnX+OD28Q+pqLXVsa0CYXQ2uYjsvOjpKQN46Cd4eDYU4YPrPFfsvlP/3WIzlBPj
-        3iZwdYbsGM0YX5X5C9UqRYzaxMkGhETZkhqV47rwoLSbgGzi+e9mXqo9+Na2+Z/yI5CSPJOqfCCl
-        5XPDY1qgdNX/SrvMuG9YRAo/tKSKNYW0B0U1HsxwayIeI1NX1do2FHzQw8HVvlqWuCqRNkspslP2
-        GwAA//8DAMClSgZ+AwAA
+        H4sIAAAAAAAAAwAAAP//jFNda9swFH33rxD3OR5x4iyO39axLRTSdWUtg7kYVb52tMiSJsntQsh/
+        H1YS20k7mB+MuEfn3HM/tAsIAV5ASoCtqWO1FuHHKY5Zch3PlvOlWT3cLj/Jq69XP+z93TdTw6hl
+        qKdfyNyJ9Y6pWgt0XMkDzAxSh61qNJ/FiyROotgDtSpQtLRKuzBWYc0lDyfjSRyO52GUHNlrxRla
+        SMnPgBBCdv7f+pQF/oGUjEenSI3W0goh7S4RAkaJNgLUWm4dlQ5GPciUdChb67IRYgA4pUTOqBB9
+        4sO3G5z7ZlEh8pvftzcvSbIR2/df7m8/rJ6jh9Vnercc5DtIb7U3VDaSdU0a4F08vUhGCEhae26F
+        Ln9B6tZoLuiEADVVU6N0rXXYZSAUo61gBmkG39Vmq0bkmmoqMxhl0EjurIcYCssbm8EeziT3wVvn
+        x0G3DJaNpeJ1G6mUyvnkvo+PR2TfjUyoShv1ZC+oUHLJ7To3SK3vxHAgwcmItwDN2cxBG1Vrlzu1
+        QZ90vjiIQr+WPTiJjqBTjoo+Ho2PW3UulxfoKPc70a0ho2yNRU/t15E2BVcDIBiU/trNW9qH8rms
+        /ke+BxhD7bDItcGCs/OK+2sG21f7r2tdk71hsGieOcPccTTtOAosaSMObwns1jqs85LLCo023D8o
+        KHU+jekspriYMgj2wV8AAAD//wMA5Oz5R14EAAA=
     headers:
       Connection:
       - keep-alive
@@ -57,7 +61,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Aug 2025 00:43:59 GMT
+      - Tue, 12 Aug 2025 07:46:55 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -73,11 +77,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '1026'
+      - '506'
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1233'
+      - '599'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -85,7 +89,7 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '3999976'
+      - '3999989'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_sync_streaming_chat_completion_with_tools.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_sync_streaming_chat_completion_with_tools.yaml
@@ -1,0 +1,134 @@
+interactions:
+- request:
+    body: "{\"messages\":[{\"role\":\"user\",\"content\":\"What's the weather in Tokyo
+      today?\"}],\"model\":\"gpt-4o-mini\",\"stream\":true,\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get
+      today's weather report\",\"parameters\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"City
+      and country e.g. Bogot\xE1, Colombia\"},\"units\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"],\"description\":\"Units
+      the temperature will be returned in.\"}},\"required\":[\"location\",\"units\"],\"additionalProperties\":false}}}]}"
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '529'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.98.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.98.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_hPd1P1Cs6Dv0a5XvrE6MZQoi","type":"function","function":{"name":"get_weather","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"l"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"b9QazmY5A3J"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"location"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"G52rt4"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"B8G9wIV5R"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Tokyo"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"4lUnceqHG"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":","}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"m47mJYdVNw0Wb"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        Japan"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"z7Usv9vK"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"afXfgVrdY"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"units"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"RqKp6C9fV"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"x9HDUR8ZF"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"c"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"4ZfCsEMJ5achD"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"elsius"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"8BU1Wpny"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"seqboFAqgjp"}
+
+
+        data: {"id":"chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS","object":"chat.completion.chunk","created":1754967030,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"0BEtcsivdx4Y"}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 12 Aug 2025 02:50:31 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-processing-ms:
+      - '335'
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '1008'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999989'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_sync_streaming_with_usage.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_sync_streaming_with_usage.yaml
@@ -1,0 +1,129 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Say hello"}],"model":"gpt-4o-mini","stream":true,"stream_options":{"include_usage":true}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '128'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.98.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.98.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"zi92deUTp"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"qYNWwV"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"yLhhuNxBIg"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        How"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"G1FEgKD"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"h4f3RE7"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"sKLw3J5Qd"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        assist"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"chKr"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        you"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"vB7dDph"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"
+        today"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"aMlWi"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"usage":null,"obfuscation":"2F68lrGmQk"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null,"obfuscation":"j1aBp"}
+
+
+        data: {"id":"chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ","object":"chat.completion.chunk","created":1754982939,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_34a54ae93c","choices":[],"usage":{"prompt_tokens":9,"completion_tokens":9,"total_tokens":18,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}},"obfuscation":"thWU9WcExQLM"}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 12 Aug 2025 07:15:39 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-processing-ms:
+      - '181'
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '296'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999995'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_tool_message_with_tool_call_id.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_tool_message_with_tool_call_id.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"messages":[{"role":"system","content":"You are a helpful assistant who
-      speaks like a pirate."},{"role":"user","content":"What is the capital of France?"}],"model":"gpt-4o-mini","max_tokens":100,"temperature":0.7}'
+    body: '{"messages":[{"role":"user","content":"What''s 2+2?"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_test123","type":"function","function":{"name":"calculate","arguments":"{\"expression\":
+      \"2+2\"}"}}]},{"role":"tool","content":"4","tool_call_id":"call_test123"}],"model":"gpt-4o-mini"}'
     headers:
       accept:
       - application/json
@@ -10,17 +10,17 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '214'
+      - '299'
       content-type:
       - application/json
       host:
       - api.openai.com
       user-agent:
-      - AsyncOpenAI/Python 1.98.0
+      - OpenAI/Python 1.98.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
-      - async:asyncio
+      - 'false'
       x-stainless-lang:
       - python
       x-stainless-os:
@@ -34,21 +34,20 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.13.2
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jJLBbtswDIbvfgpGl13sIU0cNMmtWLFLNqAbdtg6FAYj0bY2WRIkZltQ
-        5N0H2Wnsbh2wiw78+FP8ST5mAEIrsQUhW2TZeVO8WX6+2xnu7m930qij/WDWcf7z/bsvH293RuRJ
-        4fbfSPKT6rV0nTfE2tkBy0DIlKpeXa/KzWpTLtc96Jwik2SN56J0RaetLhbzRVnMr4ur9VndOi0p
-        ii18zQAAHvs39WkV/RJbmOdPkY5ixIbE9pIEIIIzKSIwRh0ZLYt8hNJZJtu3fhNCyKFDpuMMPrUE
-        Er1mNOBqeBvQSoI9wR0GHWdwA01Aq0BqPoJ7BUY3LUdIoeC6lJyDZtjTbPpboPoQMTm2B2MmAK11
-        jGlivc+HMzldnBnX+OD28Q+pqLXVsa0CYXQ2uYjsvOjpKQN46Cd4eDYU4YPrPFfsvlP/3WIzlBPj
-        3iZwdYbsGM0YX5X5C9UqRYzaxMkGhETZkhqV47rwoLSbgGzi+e9mXqo9+Na2+Z/yI5CSPJOqfCCl
-        5XPDY1qgdNX/SrvMuG9YRAo/tKSKNYW0B0U1HsxwayIeI1NX1do2FHzQw8HVvlqWuCqRNkspslP2
-        GwAA//8DAMClSgZ+AwAA
+        H4sIAAAAAAAAAwAAAP//jJJPb9swDMXv/hQEr4uL1HabNMd1h/0BhgI7DoWhSLStVZZUiR5SFPnu
+        g+w0drsO2MUH/vio92g+ZwCoFe4AZSdY9t7ktyXdffz29OP7Zh36L7fF4fOn4dA9PO6/3pUDrpLC
+        7X+R5BfVhXS9N8Ta2QnLQIIpTb3cXFU32+uy3Iygd4pMkrWe88rlvbY6L9ZFla83+eX2pO6clhRx
+        Bz8zAIDn8Zt8WkUH3MF69VLpKUbREu7OTQAYnEkVFDHqyMIyrmYonWWyo/UCPkAB9DgIE6G6WHYF
+        aoYoklM7GLMAwlrHIiUd/d2fyPHsyLjWB7ePb6TYaKtjVwcS0dn0emTncaTHDOB+TD68CoM+uN5z
+        ze6BxufK62kczvue4fbE2LEwc7mqVu8MqxWx0CYuFodSyI7UrJy3LAal3QJki8h/e3lv9hRb2/Z/
+        xs9ASvJMqvaBlJav885tgdIx/qvtvOLRMEYKv7WkmjWF9BsUNWIw04lgfIpMfd1o21LwQU930vi6
+        rMRVJeimlJgdsz8AAAD//wMAXldrPjUDAAA=
     headers:
       Connection:
       - keep-alive
@@ -57,7 +56,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Aug 2025 00:43:59 GMT
+      - Tue, 12 Aug 2025 08:12:17 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -73,11 +72,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '1026'
+      - '423'
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1233'
+      - '482'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -85,7 +84,7 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '3999976'
+      - '3999993'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:

--- a/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_user_structured_content_is_jsonified.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/cassettes/test_user_structured_content_is_jsonified.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"messages":[{"role":"system","content":"You are a helpful assistant who
-      speaks like a pirate."},{"role":"user","content":"What is the capital of France?"}],"model":"gpt-4o-mini","max_tokens":100,"temperature":0.7}'
+    body: '{"messages":[{"role":"user","content":[{"type":"text","text":"Reply with
+      OK"}]}],"model":"gpt-4o-mini","max_tokens":5}'
     headers:
       accept:
       - application/json
@@ -10,17 +10,17 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '214'
+      - '118'
       content-type:
       - application/json
       host:
       - api.openai.com
       user-agent:
-      - AsyncOpenAI/Python 1.98.0
+      - OpenAI/Python 1.98.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
-      - async:asyncio
+      - 'false'
       x-stainless-lang:
       - python
       x-stainless-os:
@@ -34,21 +34,20 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.13.2
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jJLBbtswDIbvfgpGl13sIU0cNMmtWLFLNqAbdtg6FAYj0bY2WRIkZltQ
-        5N0H2Wnsbh2wiw78+FP8ST5mAEIrsQUhW2TZeVO8WX6+2xnu7m930qij/WDWcf7z/bsvH293RuRJ
-        4fbfSPKT6rV0nTfE2tkBy0DIlKpeXa/KzWpTLtc96Jwik2SN56J0RaetLhbzRVnMr4ur9VndOi0p
-        ii18zQAAHvs39WkV/RJbmOdPkY5ixIbE9pIEIIIzKSIwRh0ZLYt8hNJZJtu3fhNCyKFDpuMMPrUE
-        Er1mNOBqeBvQSoI9wR0GHWdwA01Aq0BqPoJ7BUY3LUdIoeC6lJyDZtjTbPpboPoQMTm2B2MmAK11
-        jGlivc+HMzldnBnX+OD28Q+pqLXVsa0CYXQ2uYjsvOjpKQN46Cd4eDYU4YPrPFfsvlP/3WIzlBPj
-        3iZwdYbsGM0YX5X5C9UqRYzaxMkGhETZkhqV47rwoLSbgGzi+e9mXqo9+Na2+Z/yI5CSPJOqfCCl
-        5XPDY1qgdNX/SrvMuG9YRAo/tKSKNYW0B0U1HsxwayIeI1NX1do2FHzQw8HVvlqWuCqRNkspslP2
-        GwAA//8DAMClSgZ+AwAA
+        H4sIAAAAAAAAAwAAAP//jJJPb9swDMXv/hQCz/EQO1ma5tiiwIZt2GHNaSgMVaIdJbIoSHSRosh3
+        H+T8sbNuQC8+8MdHvUfzLRMCjIaVALWRrFpv8/tZ87o3v74+6uWXu5f1er8g//B9XT7+2BY7mCQF
+        PW9R8Vn1SVHrLbIhd8QqoGRMU4ubz/Pb20U5n/WgJY02yRrP+Zzy1jiTl9Nynk9v8mJ5Um/IKIyw
+        Er8zIYR467/Jp9O4h5WYTs6VFmOUDcLq0iQEBLKpAjJGE1k6hskAFTlG11v/+W0MAtZdlMmc66wd
+        AekcsUzhektPJ3K4mLDU+EDP8S8p1MaZuKkCykguPRiZPPT0kAnx1IftrvyDD9R6rph22D9XnLLC
+        sOIRPDEmlnZUPtevhlUaWRobR7sCJdUG9aAcFis7bWgEslHk917+NfsY27jmI+MHoBR6Rl35gNqo
+        67xDW8B0f/9ru6y4NwwRw4tRWLHBkH6Dxlp29ngVEF8jY1vVxjUYfDDH06h9tShlOZPLAmvIDtkf
+        AAAA//8DANXasPQoAwAA
     headers:
       Connection:
       - keep-alive
@@ -57,7 +56,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Aug 2025 00:43:59 GMT
+      - Tue, 12 Aug 2025 10:57:23 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -73,11 +72,11 @@ interactions:
       cf-cache-status:
       - DYNAMIC
       openai-processing-ms:
-      - '1026'
+      - '529'
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1233'
+      - '626'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -85,7 +84,7 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '3999976'
+      - '3999994'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:

--- a/sdks/python/tests/lilypad/_internal/otel/openai/test_instrument.py
+++ b/sdks/python/tests/lilypad/_internal/otel/openai/test_instrument.py
@@ -3,20 +3,65 @@
 import os
 import inspect
 from typing import Any, Generator
+from unittest.mock import Mock, patch
+from importlib.metadata import PackageNotFoundError
 
 import pytest
 from wrapt import FunctionWrapper
 from dotenv import load_dotenv
-from openai import OpenAI, AsyncOpenAI, NotFoundError
+from openai import (
+    OpenAI,
+    AsyncOpenAI,
+    NotFoundError,
+    APIStatusError,
+    RateLimitError,
+    APIConnectionError,
+)
 from pydantic import BaseModel
 from opentelemetry import trace
 from inline_snapshot import snapshot
+from openai.types.chat import ChatCompletion
 from opentelemetry.trace import ProxyTracerProvider
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from lilypad._internal.otel.openai.instrument import instrument_openai
+
+
+class ReadOnlyCompletions:
+    """Mock completions object with read-only properties."""
+
+    @property
+    def create(self):
+        return Mock()
+
+    @property
+    def parse(self):
+        return Mock()
+
+
+class PartialReadOnlyCompletions:
+    """Mock completions object with writable create and read-only parse."""
+
+    def __init__(self):
+        self.create = Mock()
+
+    @property
+    def parse(self):
+        return Mock()
+
+
+@pytest.fixture
+def readonly_completions():
+    """Fixture providing a completions mock with all read-only properties."""
+    return ReadOnlyCompletions()
+
+
+@pytest.fixture
+def partial_readonly_completions():
+    """Fixture providing a completions mock with writable create and read-only parse."""
+    return PartialReadOnlyCompletions()
 
 
 def extract_span_data(span: ReadableSpan) -> dict[str, Any]:
@@ -82,18 +127,14 @@ def async_client(api_key: str) -> AsyncOpenAI:
 @pytest.mark.vcr()
 def test_sync_chat_completion_simple(
     client: OpenAI, span_exporter: InMemorySpanExporter
-):
+) -> None:
     """Test basic chat completion with span verification."""
     response = client.chat.completions.create(
         model="gpt-4o-mini",
         messages=[{"role": "user", "content": "Hello, say 'Hi' back to me"}],
     )
 
-    assert response.id
-    assert response.model
-    assert response.choices
-    assert len(response.choices) > 0
-    assert response.choices[0].message.content
+    assert isinstance(response, ChatCompletion)
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -139,18 +180,14 @@ def test_sync_chat_completion_simple(
 @pytest.mark.asyncio
 async def test_async_chat_completion_simple(
     async_client: AsyncOpenAI, span_exporter: InMemorySpanExporter
-):
+) -> None:
     """Test async chat completion with span verification."""
     response = await async_client.chat.completions.create(
         model="gpt-4o-mini",
         messages=[{"role": "user", "content": "Hello, say 'Hi' back to me"}],
     )
 
-    assert response.id
-    assert response.model
-    assert response.choices
-    assert len(response.choices) > 0
-    assert response.choices[0].message.content
+    assert isinstance(response, ChatCompletion)
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -195,7 +232,7 @@ async def test_async_chat_completion_simple(
 @pytest.mark.vcr()
 def test_sync_chat_completion_with_system(
     client: OpenAI, span_exporter: InMemorySpanExporter
-):
+) -> None:
     """Test chat completion with system message and span verification."""
     response = client.chat.completions.create(
         model="gpt-4o-mini",
@@ -210,9 +247,7 @@ def test_sync_chat_completion_with_system(
         max_tokens=100,
     )
 
-    assert response.id
-    assert response.choices
-    assert response.choices[0].message.content
+    assert isinstance(response, ChatCompletion)
     assert (
         response.usage
         and response.usage.total_tokens <= 100 + response.usage.prompt_tokens
@@ -268,31 +303,40 @@ def test_sync_chat_completion_with_system(
 
 
 @pytest.mark.vcr()
-@pytest.mark.asyncio
-async def test_async_chat_completion_with_system(
-    async_client: AsyncOpenAI, span_exporter: InMemorySpanExporter
-):
-    """Test chat completion with system message and span verification."""
-    response = await async_client.chat.completions.create(
+def test_sync_chat_completion_with_tools(
+    client: OpenAI, span_exporter: InMemorySpanExporter
+) -> None:
+    response = client.chat.completions.create(
         model="gpt-4o-mini",
-        messages=[
+        messages=[{"role": "user", "content": "What's the weather in Tokyo today?"}],
+        tools=[
             {
-                "role": "system",
-                "content": "You are a helpful assistant who speaks like a pirate.",
-            },
-            {"role": "user", "content": "What is the capital of France?"},
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get today's weather report",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": "City and country e.g. Bogotá, Colombia",
+                            },
+                            "units": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"],
+                                "description": "Units the temperature will be returned in.",
+                            },
+                        },
+                        "required": ["location", "units"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
         ],
-        temperature=0.7,
-        max_tokens=100,
     )
 
-    assert response.id
-    assert response.choices
-    assert response.choices[0].message.content
-    assert (
-        response.usage
-        and response.usage.total_tokens <= 100 + response.usage.prompt_tokens
-    )
+    assert isinstance(response, ChatCompletion)
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -302,40 +346,31 @@ async def test_async_chat_completion_with_system(
             "attributes": {
                 "gen_ai.operation.name": "chat",
                 "gen_ai.request.model": "gpt-4o-mini",
-                "gen_ai.request.temperature": 0.7,
-                "gen_ai.request.max_tokens": 100,
                 "server.address": "api.openai.com",
                 "gen_ai.system": "openai",
                 "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
-                "gen_ai.response.finish_reasons": ("stop",),
-                "gen_ai.response.id": "chatcmpl-C3XPKltmZDKcldynQl8s0wMLYRDKl",
+                "gen_ai.response.finish_reasons": ("tool_calls",),
+                "gen_ai.response.id": "chatcmpl-C3XhNKgmTCR5hS0CSl5qATizQP87Y",
                 "gen_ai.openai.request.service_tier": "default",
-                "gen_ai.usage.input_tokens": 29,
-                "gen_ai.usage.output_tokens": 25,
+                "gen_ai.usage.input_tokens": 79,
+                "gen_ai.usage.output_tokens": 21,
             },
             "status": {"status_code": "UNSET", "description": None},
             "events": [
                 {
-                    "name": "gen_ai.system.message",
-                    "attributes": {
-                        "gen_ai.system": "openai",
-                        "content": "You are a helpful assistant who speaks like a pirate.",
-                    },
-                },
-                {
                     "name": "gen_ai.user.message",
                     "attributes": {
                         "gen_ai.system": "openai",
-                        "content": "What is the capital of France?",
+                        "content": "What's the weather in Tokyo today?",
                     },
                 },
                 {
                     "name": "gen_ai.choice",
                     "attributes": {
                         "gen_ai.system": "openai",
-                        "message": '{"role":"assistant","content":"Arrr, matey! The capital of France be Paris! A grand city o\' lights and romance, it be!"}',
+                        "message": '{"role":"assistant","tool_calls":[{"function":{"arguments":"{\\"location\\":\\"Tokyo, Japan\\",\\"units\\":\\"celsius\\"}","name":"get_weather"},"id":"call_QsfqVdAAIGjpAmWZOkYtPUIY","type":"function"}]}',
                         "index": 0,
-                        "finish_reason": "stop",
+                        "finish_reason": "tool_calls",
                     },
                 },
             ],
@@ -346,7 +381,7 @@ async def test_async_chat_completion_with_system(
 @pytest.mark.vcr()
 def test_sync_streaming_chat_completion(
     client: OpenAI, span_exporter: InMemorySpanExporter
-):
+) -> None:
     """Test streaming chat completion with span verification."""
     stream = client.chat.completions.create(
         model="gpt-4o-mini",
@@ -374,6 +409,7 @@ def test_sync_streaming_chat_completion(
                 "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
                 "gen_ai.response.id": "chatcmpl-C2IjQMIDb4wsN7RAS4yUy4SypFyHv",
                 "gen_ai.openai.response.service_tier": "default",
+                "gen_ai.response.finish_reasons": ("stop",),
             },
             "status": {"status_code": "UNSET", "description": None},
             "events": [
@@ -399,7 +435,7 @@ def test_sync_streaming_chat_completion(
 @pytest.mark.asyncio
 async def test_async_streaming_chat_completion(
     async_client: AsyncOpenAI, span_exporter: InMemorySpanExporter
-):
+) -> None:
     """Test async streaming with span verification."""
     stream = await async_client.chat.completions.create(
         model="gpt-4o-mini",
@@ -427,6 +463,7 @@ async def test_async_streaming_chat_completion(
                 "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
                 "gen_ai.response.id": "chatcmpl-C2IjRrSL7E98KQlzfRfuGI5aQ5nxZ",
                 "gen_ai.openai.response.service_tier": "default",
+                "gen_ai.response.finish_reasons": ("stop",),
             },
             "status": {"status_code": "UNSET", "description": None},
             "events": [
@@ -449,7 +486,88 @@ async def test_async_streaming_chat_completion(
 
 
 @pytest.mark.vcr()
-def test_sync_parse_with_pydantic(client: OpenAI, span_exporter: InMemorySpanExporter):
+def test_sync_streaming_chat_completion_with_tools(
+    client: OpenAI, span_exporter: InMemorySpanExporter
+) -> None:
+    stream = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "What's the weather in Tokyo today?"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get today's weather report",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "location": {
+                                "type": "string",
+                                "description": "City and country e.g. Bogotá, Colombia",
+                            },
+                            "units": {
+                                "type": "string",
+                                "enum": ["celsius", "fahrenheit"],
+                                "description": "Units the temperature will be returned in.",
+                            },
+                        },
+                        "required": ["location", "units"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        ],
+        stream=True,
+    )
+
+    chunks = []
+    for chunk in stream:
+        chunks.append(chunk)
+
+    assert len(chunks) > 0
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "server.address": "api.openai.com",
+                "gen_ai.system": "openai",
+                "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+                "gen_ai.response.id": "chatcmpl-C3ZNmCTxVz6gr1eQLl32BjSeKbXsS",
+                "gen_ai.openai.response.service_tier": "default",
+                "gen_ai.response.finish_reasons": ("tool_calls",),
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "content": "What's the weather in Tokyo today?",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "message": '{"role": "assistant", "tool_calls": [{"id": "call_hPd1P1Cs6Dv0a5XvrE6MZQoi", "type": "function", "function": {"name": "get_weather", "arguments": "{\\"location\\":\\"Tokyo, Japan\\",\\"units\\":\\"celsius\\"}"}}]}',
+                        "index": 0,
+                        "finish_reason": "tool_calls",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_parse_with_pydantic(
+    client: OpenAI, span_exporter: InMemorySpanExporter
+) -> None:
     """Test parse method with Pydantic and span verification."""
 
     class CalendarEvent(BaseModel):
@@ -520,7 +638,7 @@ def test_sync_parse_with_pydantic(client: OpenAI, span_exporter: InMemorySpanExp
 @pytest.mark.asyncio
 async def test_async_parse_with_pydantic(
     async_client: AsyncOpenAI, span_exporter: InMemorySpanExporter
-):
+) -> None:
     """Test async parse with span verification."""
 
     class CalendarEvent(BaseModel):
@@ -587,7 +705,7 @@ async def test_async_parse_with_pydantic(
     )
 
 
-def test_preserves_method_signatures():
+def test_preserves_method_signatures() -> None:
     """Test that instrumentation preserves original method signatures."""
     fresh_client = OpenAI(api_key="test")
     original_create_sig = inspect.signature(fresh_client.chat.completions.create)
@@ -606,7 +724,7 @@ def test_preserves_method_signatures():
     )
 
 
-def test_multiple_clients_independent(api_key: str):
+def test_multiple_clients_independent(api_key: str) -> None:
     """Test that multiple clients can be instrumented independently."""
 
     client1 = OpenAI(api_key=api_key)
@@ -627,7 +745,93 @@ def test_multiple_clients_independent(api_key: str):
 
 
 @pytest.mark.vcr()
-def test_error_handling(client: OpenAI, span_exporter: InMemorySpanExporter):
+def test_tool_message_with_tool_call_id(
+    client: OpenAI, span_exporter: InMemorySpanExporter
+) -> None:
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "user", "content": "What's 2+2?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_test123",
+                        "type": "function",
+                        "function": {
+                            "name": "calculate",
+                            "arguments": '{"expression": "2+2"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": "4",
+                "tool_call_id": "call_test123",
+            },
+        ],
+    )
+
+    assert response.choices[0].message.content
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "server.address": "api.openai.com",
+                "gen_ai.system": "openai",
+                "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+                "gen_ai.response.finish_reasons": ("stop",),
+                "gen_ai.response.id": "chatcmpl-C3ePBKySN70rmIC2xHDuxhkqbJP3u",
+                "gen_ai.openai.request.service_tier": "default",
+                "gen_ai.usage.input_tokens": 36,
+                "gen_ai.usage.output_tokens": 8,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "content": "What's 2+2?",
+                    },
+                },
+                {
+                    "name": "gen_ai.assistant.message",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "tool_calls": '[{"function":{"name":"calculate","arguments":"{\\"expression\\": \\"2+2\\"}"},"id":"call_test123","type":"function"}]',
+                    },
+                },
+                {
+                    "name": "gen_ai.tool.message",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "content": "4",
+                        "id": "call_test123",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "message": '{"role":"assistant","content":"2 + 2 equals 4."}',
+                        "index": 0,
+                        "finish_reason": "stop",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_error_handling(client: OpenAI, span_exporter: InMemorySpanExporter) -> None:
     """Test error handling and span error recording."""
     with pytest.raises(NotFoundError):
         client.chat.completions.create(
@@ -661,7 +865,7 @@ def test_error_handling(client: OpenAI, span_exporter: InMemorySpanExporter):
     )
 
 
-def test_client_marked_as_instrumented():
+def test_client_marked_as_instrumented() -> None:
     """Test that client is marked as instrumented after instrumentation."""
     client = OpenAI(api_key="test")
 
@@ -673,7 +877,7 @@ def test_client_marked_as_instrumented():
     assert client._lilypad_instrumented is True  # pyright: ignore[reportAttributeAccessIssue]
 
 
-def test_instrumentation_idempotent():
+def test_instrumentation_idempotent() -> None:
     """Test that instrumentation is truly idempotent."""
     client = OpenAI(api_key="test")
 
@@ -689,7 +893,7 @@ def test_instrumentation_idempotent():
     assert second_parse is first_parse
 
 
-def test_async_instrumentation_idempotent():
+def test_async_instrumentation_idempotent() -> None:
     """Test that async instrumentation is truly idempotent."""
     client = AsyncOpenAI(api_key="test")
 
@@ -705,7 +909,7 @@ def test_async_instrumentation_idempotent():
     assert second_parse is first_parse
 
 
-def test_preserves_async_nature():
+def test_preserves_async_nature() -> None:
     """Test that async methods remain async after patching."""
     from pydantic import BaseModel
 
@@ -733,3 +937,483 @@ def test_preserves_async_nature():
     assert inspect.iscoroutine(parse_result_after)
     create_result_after.close()
     parse_result_after.close()
+
+
+def test_sync_chat_completion_api_connection_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test sync chat completion with APIConnectionError."""
+    mock_client = Mock(spec=OpenAI)
+
+    mock_request = Mock()
+    mock_request.url = "https://api.openai.com/v1/chat/completions"
+
+    original_create = Mock(
+        side_effect=APIConnectionError(
+            message="Connection failed", request=mock_request
+        )
+    )
+    mock_client.chat.completions.create = original_create
+
+    instrument_openai(mock_client)
+
+    with pytest.raises(APIConnectionError):
+        mock_client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.system": "openai",
+                "error.type": "APIConnectionError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Connection failed",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_chat_completion_api_connection_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test async chat completion with APIConnectionError."""
+    mock_client = Mock(spec=AsyncOpenAI)
+
+    async def create_error(*args, **kwargs):
+        mock_request = Mock()
+        mock_request.url = "https://api.openai.com/v1/chat/completions"
+        raise APIConnectionError(message="Connection failed", request=mock_request)
+
+    original_create = Mock(side_effect=create_error)
+    mock_client.chat.completions.create = original_create
+
+    instrument_openai(mock_client)
+
+    with pytest.raises(APIConnectionError):
+        await mock_client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.system": "openai",
+                "error.type": "APIConnectionError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Connection failed",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+def test_sync_parse_rate_limit_error(span_exporter: InMemorySpanExporter) -> None:
+    """Test sync parse with RateLimitError."""
+    mock_client = Mock(spec=OpenAI)
+
+    original_parse = Mock(
+        side_effect=RateLimitError(
+            message="Rate limit exceeded",
+            response=Mock(status_code=429),
+            body={"error": {"message": "Rate limit exceeded"}},
+        )
+    )
+    mock_client.chat.completions.parse = original_parse
+
+    instrument_openai(mock_client)
+
+    class TestModel(BaseModel):
+        test: str
+
+    with pytest.raises(RateLimitError):
+        mock_client.chat.completions.parse(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Hello"}],
+            response_format=TestModel,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.openai.request.response_format": "TestModel",
+                "gen_ai.system": "openai",
+                "error.type": "RateLimitError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Rate limit exceeded",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_parse_rate_limit_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test async parse with RateLimitError."""
+    mock_client = Mock(spec=AsyncOpenAI)
+
+    async def parse_error(*args, **kwargs):
+        raise RateLimitError(
+            message="Rate limit exceeded",
+            response=Mock(status_code=429),
+            body={"error": {"message": "Rate limit exceeded"}},
+        )
+
+    original_parse = Mock(side_effect=parse_error)
+    mock_client.chat.completions.parse = original_parse
+
+    instrument_openai(mock_client)
+
+    class TestModel(BaseModel):
+        test: str
+
+    with pytest.raises(RateLimitError):
+        await mock_client.chat.completions.parse(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Hello"}],
+            response_format=TestModel,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.openai.request.response_format": "TestModel",
+                "gen_ai.system": "openai",
+                "error.type": "RateLimitError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Rate limit exceeded",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+def test_sync_streaming_api_status_error(span_exporter: InMemorySpanExporter) -> None:
+    """Test sync streaming with APIStatusError."""
+    mock_client = Mock(spec=OpenAI)
+
+    original_create = Mock(
+        side_effect=APIStatusError(
+            message="Internal server error",
+            response=Mock(status_code=500),
+            body={"error": {"message": "Internal server error"}},
+        )
+    )
+    mock_client.chat.completions.create = original_create
+
+    instrument_openai(mock_client)
+
+    with pytest.raises(APIStatusError):
+        mock_client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Hello"}],
+            stream=True,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.system": "openai",
+                "error.type": "APIStatusError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Internal server error",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+def test_sync_wrapping_failure_create(
+    caplog: pytest.LogCaptureFixture,
+    readonly_completions: Mock,
+) -> None:
+    """Test sync client when wrapping create method fails."""
+    mock_client = Mock(spec=OpenAI)
+    mock_client.chat.completions = readonly_completions
+
+    with caplog.at_level("WARNING"):
+        instrument_openai(mock_client)
+
+    assert hasattr(mock_client, "_lilypad_instrumented")
+    assert mock_client._lilypad_instrumented is True
+    assert "Failed to wrap Completions.create: AttributeError" in caplog.text
+
+
+def test_sync_wrapping_failure_parse(
+    caplog: pytest.LogCaptureFixture,
+    partial_readonly_completions: Mock,
+) -> None:
+    """Test sync client when wrapping parse method fails."""
+    mock_client = Mock(spec=OpenAI)
+    mock_client.chat.completions = partial_readonly_completions
+
+    with caplog.at_level("WARNING"):
+        instrument_openai(mock_client)
+
+    assert hasattr(mock_client, "_lilypad_instrumented")
+    assert mock_client._lilypad_instrumented is True
+    assert "Failed to wrap Completions.parse: AttributeError" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_wrapping_failure_create(
+    caplog: pytest.LogCaptureFixture,
+    readonly_completions: Mock,
+) -> None:
+    """Test async client when wrapping create method fails."""
+    mock_client = Mock(spec=AsyncOpenAI)
+    mock_client.chat.completions = readonly_completions
+
+    with caplog.at_level("WARNING"):
+        instrument_openai(mock_client)
+
+    assert hasattr(mock_client, "_lilypad_instrumented")
+    assert mock_client._lilypad_instrumented is True
+    assert "Failed to wrap AsyncCompletions.create: AttributeError" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_wrapping_failure_parse(
+    caplog: pytest.LogCaptureFixture,
+    partial_readonly_completions: Mock,
+) -> None:
+    """Test async client when wrapping parse method fails."""
+    mock_client = Mock(spec=AsyncOpenAI)
+    mock_client.chat.completions = partial_readonly_completions
+
+    with caplog.at_level("WARNING"):
+        instrument_openai(mock_client)
+
+    assert hasattr(mock_client, "_lilypad_instrumented")
+    assert mock_client._lilypad_instrumented is True
+    assert "Failed to wrap AsyncCompletions.parse: AttributeError" in caplog.text
+
+
+def test_sync_partial_wrapping_failure(
+    caplog: pytest.LogCaptureFixture,
+    partial_readonly_completions: Mock,
+) -> None:
+    """Test sync client when only parse wrapping fails, create should still be wrapped."""
+    mock_client = Mock(spec=OpenAI)
+    mock_client.chat.completions = partial_readonly_completions
+
+    with caplog.at_level("WARNING"):
+        instrument_openai(mock_client)
+
+    assert hasattr(mock_client, "_lilypad_instrumented")
+    assert mock_client._lilypad_instrumented is True
+    assert isinstance(mock_client.chat.completions.create, FunctionWrapper)
+    assert "Failed to wrap Completions.parse: AttributeError" in caplog.text
+
+
+def test_package_not_found_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test handling of PackageNotFoundError when determining lilypad-sdk version."""
+
+    with patch(
+        "lilypad._internal.otel.openai.instrument.version",
+        side_effect=PackageNotFoundError("Package lilypad-sdk not found"),
+    ):
+        mock_client = Mock(spec=OpenAI)
+
+        with caplog.at_level("DEBUG"):
+            instrument_openai(mock_client)
+
+        assert hasattr(mock_client, "_lilypad_instrumented")
+        assert mock_client._lilypad_instrumented is True
+        assert "Could not determine lilypad-sdk version" in caplog.text
+        assert isinstance(mock_client.chat.completions.create, FunctionWrapper)
+        assert isinstance(mock_client.chat.completions.parse, FunctionWrapper)
+
+
+@pytest.mark.vcr()
+def test_sync_streaming_with_usage(
+    client: OpenAI, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test streaming with usage information enabled."""
+    stream = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "Say hello"}],
+        stream=True,
+        stream_options={"include_usage": True},
+    )
+
+    chunks = []
+    for chunk in stream:
+        chunks.append(chunk)
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "server.address": "api.openai.com",
+                "gen_ai.system": "openai",
+                "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+                "gen_ai.response.id": "chatcmpl-C3dWNVMQnBtnziHMFBczZApO4CVcQ",
+                "gen_ai.openai.response.service_tier": "default",
+                "gen_ai.usage.input_tokens": 9,
+                "gen_ai.usage.output_tokens": 9,
+                "gen_ai.response.finish_reasons": ("stop",),
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {"gen_ai.system": "openai", "content": "Say hello"},
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "message": '{"role": "assistant", "content": "Hello! How can I assist you today?"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_user_structured_content_is_jsonified(
+    client: OpenAI, span_exporter: InMemorySpanExporter
+) -> None:
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Reply with OK"},
+                ],
+            }
+        ],
+        max_tokens=5,
+    )
+    assert isinstance(response, ChatCompletion)
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.request.max_tokens": 5,
+                "server.address": "api.openai.com",
+                "gen_ai.system": "openai",
+                "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+                "gen_ai.response.finish_reasons": ("stop",),
+                "gen_ai.response.id": "chatcmpl-C3gyxiSITd8HBvUUx6opELU2TMj1k",
+                "gen_ai.openai.request.service_tier": "default",
+                "gen_ai.usage.input_tokens": 10,
+                "gen_ai.usage.output_tokens": 1,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "content": '[{"type":"text","text":"Reply with OK"}]',
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "openai",
+                        "message": '{"role":"assistant","content":"OK"}',
+                        "index": 0,
+                        "finish_reason": "stop",
+                    },
+                },
+            ],
+        }
+    )

--- a/sdks/python/tests/lilypad/_internal/otel/test_utils.py
+++ b/sdks/python/tests/lilypad/_internal/otel/test_utils.py
@@ -1,30 +1,112 @@
+from typing import Any, Iterator, AsyncIterator
 from unittest.mock import Mock
 
 import httpx
+import pytest
+from inline_snapshot import snapshot
+from opentelemetry.trace import Span, Status, StatusCode
+
 from lilypad._internal.otel.utils import (
+    BaseMetadata,
     ChoiceBuffer,
+    ChunkHandler,
+    StreamWrapper,
+    StreamProtocol,
     ToolCallBuffer,
+    AsyncStreamWrapper,
+    AsyncStreamProtocol,
     set_server_address_and_port,
 )
 
 
-def test_choice_buffer_init():
+class MockMetadata(BaseMetadata): ...
+
+
+class MockChunk:
+    def __init__(self, content: str, finish_reason: str | None = None) -> None:
+        self.content = content
+        self.finish_reason = finish_reason
+        self.usage = (
+            {"prompt_tokens": 10, "completion_tokens": 5} if finish_reason else None
+        )
+
+
+class MockChunkHandler(ChunkHandler[MockChunk, MockMetadata]):
+    def extract_metadata(self, chunk: MockChunk, metadata: MockMetadata) -> None:
+        if chunk.usage:
+            metadata["prompt_tokens"] = chunk.usage.get("prompt_tokens")
+            metadata["completion_tokens"] = chunk.usage.get("completion_tokens")
+
+    def process_chunk(self, chunk: MockChunk, buffers: list[ChoiceBuffer]) -> None:
+        if not buffers:
+            buffers.append(ChoiceBuffer(0))
+
+        buffer = buffers[0]
+        if chunk.content:
+            buffer.append_text_content(chunk.content)
+        if chunk.finish_reason:
+            buffer.finish_reason = chunk.finish_reason
+
+
+class MockStream(StreamProtocol[MockChunk]):
+    def __init__(self, chunks: list[MockChunk]) -> None:
+        self.chunks = chunks
+        self.index = 0
+        self.closed = False
+
+    def __iter__(self) -> Iterator[MockChunk]:
+        return self  # pragma: no cover
+
+    def __next__(self) -> MockChunk:
+        if self.index >= len(self.chunks):
+            raise StopIteration
+        chunk = self.chunks[self.index]
+        self.index += 1
+        return chunk
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class MockAsyncStream(AsyncStreamProtocol[MockChunk]):
+    def __init__(self, chunks: list[MockChunk]) -> None:
+        self.chunks = chunks
+        self.index = 0
+        self.closed = False
+
+    def __aiter__(self) -> AsyncIterator[MockChunk]:
+        return self  # pragma: no cover
+
+    async def __anext__(self) -> MockChunk:
+        if self.index >= len(self.chunks):
+            raise StopAsyncIteration
+        chunk = self.chunks[self.index]
+        self.index += 1
+        return chunk
+
+    async def aclose(self) -> None:
+        self.closed = True  # pragma: no cover
+
+
+def test_choice_buffer_init() -> None:
     buffer = ChoiceBuffer(0)
-    assert buffer.index == 0
-    assert buffer.finish_reason is None
-    assert buffer.text_content == []
-    assert buffer.tool_calls_buffers == []
+    assert (
+        buffer.index,
+        buffer.finish_reason,
+        buffer.text_content,
+        buffer.tool_calls_buffers,
+    ) == snapshot((0, None, [], []))
 
 
-def test_append_text_content():
+def test_append_text_content() -> None:
     buffer = ChoiceBuffer(0)
     buffer.append_text_content("Hello")
     buffer.append_text_content(" World")
 
-    assert buffer.text_content == ["Hello", " World"]
+    assert buffer.text_content == snapshot(["Hello", " World"])
 
 
-def test_append_tool_call():
+def test_append_tool_call() -> None:
     buffer = ChoiceBuffer(0)
 
     tool_call = Mock()
@@ -37,12 +119,17 @@ def test_append_tool_call():
     buffer.append_tool_call(tool_call)
 
     assert len(buffer.tool_calls_buffers) == 1
-    assert buffer.tool_calls_buffers[0] is not None
-    assert buffer.tool_calls_buffers[0].tool_call_id == "call_123"
-    assert buffer.tool_calls_buffers[0].function_name == "test_func"
+    assert vars(buffer.tool_calls_buffers[0]) == snapshot(
+        {
+            "index": 0,
+            "tool_call_id": "call_123",
+            "function_name": "test_func",
+            "arguments": ['{"arg": "value"}'],
+        }
+    )
 
 
-def test_append_multiple_tool_calls():
+def test_append_multiple_tool_calls() -> None:
     buffer = ChoiceBuffer(0)
 
     tool_call1 = Mock(index=0, id="call_1")
@@ -57,82 +144,318 @@ def test_append_multiple_tool_calls():
     buffer.append_tool_call(tool_call3)
 
     assert len(buffer.tool_calls_buffers) == 2
-    assert buffer.tool_calls_buffers[0] is not None
-    assert buffer.tool_calls_buffers[0].arguments == ['{"a": 1}', '{"c": 3}']
-    assert buffer.tool_calls_buffers[1] is not None
-    assert buffer.tool_calls_buffers[1].arguments == ['{"b": 2}']
+    tool_call_buffer_0 = buffer.tool_calls_buffers[0]
+    assert tool_call_buffer_0 is not None
+    assert tool_call_buffer_0.arguments == snapshot(['{"a": 1}', '{"c": 3}'])
+    tool_call_buffer_1 = buffer.tool_calls_buffers[1]
+    assert tool_call_buffer_1 is not None
+    assert tool_call_buffer_1.arguments == snapshot(['{"b": 2}'])
 
 
-def test_tool_call_buffer_init():
+def test_tool_call_buffer_init() -> None:
     buffer = ToolCallBuffer(0, "call_123", "test_func")
 
-    assert buffer.index == 0
-    assert buffer.tool_call_id == "call_123"
-    assert buffer.function_name == "test_func"
-    assert buffer.arguments == []
+    assert vars(buffer) == snapshot(
+        {
+            "index": 0,
+            "tool_call_id": "call_123",
+            "function_name": "test_func",
+            "arguments": [],
+        }
+    )
 
 
-def test_append_arguments():
+def test_append_arguments() -> None:
     buffer = ToolCallBuffer(0, "call_123", "test_func")
 
     buffer.append_arguments('{"part1": ')
     buffer.append_arguments('"value",')
     buffer.append_arguments(' "part2": "value2"}')
 
-    assert buffer.arguments == ['{"part1": ', '"value",', ' "part2": "value2"}']
+    assert buffer.arguments == snapshot(
+        ['{"part1": ', '"value",', ' "part2": "value2"}']
+    )
 
 
-def test_set_server_address_from_base_url():
-    attributes = {}
+def test_set_server_address_from_base_url() -> None:
+    attributes: dict[str, Any] = {}
     client_instance = Mock()
     client_instance._client = httpx.Client(base_url="https://api.openai.com:443")
 
     set_server_address_and_port(client_instance, attributes)
 
-    assert attributes["server.address"] == "api.openai.com"
-    assert "server.port" not in attributes
+    assert attributes == {"server.address": "api.openai.com"}
 
 
-def test_set_server_address_from_url_string():
-    attributes = {}
-    client_instance = Mock()
-    client_instance._client = httpx.Client(base_url="https://api.example.com:8080")
-
-    set_server_address_and_port(client_instance, attributes)
-
-    assert attributes["server.address"] == "api.example.com"
-    assert attributes["server.port"] == 8080
-
-
-def test_set_server_address_no_port():
-    attributes = {}
+def test_set_server_address_no_port() -> None:
+    attributes: dict[str, Any] = {}
     client_instance = Mock()
     client_instance._client = httpx.Client(base_url="https://api.example.com")
 
     set_server_address_and_port(client_instance, attributes)
 
-    assert attributes["server.address"] == "api.example.com"
-    assert "server.port" not in attributes
+    assert attributes == {"server.address": "api.example.com"}
 
 
-def test_set_server_address_http():
-    attributes = {}
+def test_set_server_address_http() -> None:
+    attributes: dict[str, Any] = {}
     client_instance = Mock()
     client_instance._client = httpx.Client(base_url="http://localhost:8080")
 
     set_server_address_and_port(client_instance, attributes)
 
-    assert attributes["server.address"] == "localhost"
-    assert attributes["server.port"] == 8080
+    assert attributes == {"server.address": "localhost", "server.port": 8080}
 
 
-def test_set_server_address_no_base_url():
-    attributes = {}
+def test_set_server_address_no_base_url() -> None:
+    attributes: dict[str, Any] = {}
     client_instance = Mock()
     client_instance._client = Mock()
     client_instance._client.base_url = None
 
     set_server_address_and_port(client_instance, attributes)
 
-    assert "server.address" not in attributes
-    assert "server.port" not in attributes
+    assert attributes == {}
+
+
+def test_stream_wrapper_context_manager_with_exception() -> None:
+    span = Mock(spec=Span)
+    stream = MockStream([MockChunk("Hello")])
+    metadata = MockMetadata()
+    chunk_handler = MockChunkHandler()
+    cleanup_handler = Mock()
+
+    wrapper = StreamWrapper(span, stream, metadata, chunk_handler, cleanup_handler)
+
+    with pytest.raises(ValueError), wrapper:
+        raise ValueError("Test error")
+
+    span.set_status.assert_called_once()
+    status_call_args = span.set_status.call_args[0][0]
+    assert isinstance(status_call_args, Status)
+    assert status_call_args.status_code == StatusCode.ERROR
+    assert "Test error" in str(status_call_args.description)
+
+    span.set_attribute.assert_called_once_with("error.type", "ValueError")
+    cleanup_handler.assert_called_once()
+    span.end.assert_called_once()
+
+
+def test_stream_wrapper_iteration() -> None:
+    span = Mock(spec=Span)
+    chunks = [MockChunk("Hello "), MockChunk("World"), MockChunk("!", "stop")]
+    stream = MockStream(chunks)
+    metadata = MockMetadata()
+    chunk_handler = MockChunkHandler()
+
+    processed_buffers: list[ChoiceBuffer] = []
+
+    def cleanup(
+        _span: Span, metadata_arg: MockMetadata, buffers: list[ChoiceBuffer]
+    ) -> None:
+        processed_buffers.extend(buffers)
+        assert metadata_arg == {"prompt_tokens": 10, "completion_tokens": 5}
+
+    cleanup_handler = Mock(side_effect=cleanup)
+
+    wrapper = StreamWrapper(span, stream, metadata, chunk_handler, cleanup_handler)
+
+    collected_chunks = list(wrapper)
+
+    assert collected_chunks == chunks
+    assert len(processed_buffers) == 1
+    buffer = processed_buffers[0]
+    assert (
+        buffer.index,
+        buffer.finish_reason,
+        buffer.text_content,
+        len(buffer.tool_calls_buffers),
+    ) == snapshot((0, "stop", ["Hello ", "World", "!"], 0))
+    assert metadata == {"prompt_tokens": 10, "completion_tokens": 5}
+
+    cleanup_handler.assert_called_once()
+    span.end.assert_called_once()
+
+
+def test_stream_wrapper_iteration_with_exception() -> None:
+    span = Mock(spec=Span)
+
+    class ErrorStream(StreamProtocol[MockChunk]):
+        def __init__(self) -> None:
+            self.index = 0
+
+        def __iter__(self) -> Iterator[MockChunk]:
+            return self  # pragma: no cover
+
+        def __next__(self) -> MockChunk:
+            if self.index == 0:
+                self.index += 1
+                return MockChunk("chunk1")
+            raise RuntimeError("Stream error")
+
+        def close(self) -> None: ...
+
+    stream = ErrorStream()
+    metadata = MockMetadata()
+    chunk_handler = MockChunkHandler()
+    cleanup_handler = Mock()
+
+    wrapper = StreamWrapper(span, stream, metadata, chunk_handler, cleanup_handler)
+
+    with pytest.raises(RuntimeError, match="Stream error"):
+        list(wrapper)
+
+    span.set_status.assert_called_once()
+    status_call_args = span.set_status.call_args[0][0]
+    assert isinstance(status_call_args, Status)
+    assert (status_call_args.status_code, status_call_args.description) == snapshot(
+        (StatusCode.ERROR, "Stream error")
+    )
+
+    span.set_attribute.assert_called_once_with("error.type", "RuntimeError")
+    cleanup_handler.assert_called_once()
+    span.end.assert_called_once()
+
+    assert len(wrapper.choice_buffers) == 1
+    assert wrapper.choice_buffers[0].text_content == snapshot(["chunk1"])
+
+
+def test_stream_wrapper_close() -> None:
+    span = Mock(spec=Span)
+    stream = MockStream([MockChunk("Hello")])
+    metadata = MockMetadata()
+    chunk_handler = MockChunkHandler()
+    cleanup_handler = Mock()
+
+    wrapper = StreamWrapper(span, stream, metadata, chunk_handler, cleanup_handler)
+
+    assert not stream.closed
+
+    wrapper.close()
+
+    assert stream.closed
+
+    cleanup_handler.assert_called_once()
+    span.end.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_wrapper_context_manager_with_exception() -> None:
+    span = Mock(spec=Span)
+    stream = Mock(spec=AsyncStreamProtocol)
+    metadata = MockMetadata()
+    chunk_handler = Mock(spec=ChunkHandler)
+    cleanup_handler = Mock()
+
+    wrapper = AsyncStreamWrapper(span, stream, metadata, chunk_handler, cleanup_handler)
+
+    with pytest.raises(ValueError):
+        async with wrapper:
+            raise ValueError("Test error")
+
+    span.set_status.assert_called_once()
+    status_call_args = span.set_status.call_args[0][0]
+    assert isinstance(status_call_args, Status)
+    assert status_call_args.status_code == StatusCode.ERROR
+    span.set_attribute.assert_called_once_with("error.type", "ValueError")
+    cleanup_handler.assert_called_once()
+    span.end.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_wrapper_iteration() -> None:
+    span = Mock(spec=Span)
+    chunks = [MockChunk("Hello "), MockChunk("async"), MockChunk("!", "stop")]
+    stream = MockAsyncStream(chunks)
+    metadata = MockMetadata()
+    chunk_handler = MockChunkHandler()
+
+    processed_buffers: list[ChoiceBuffer] = []
+
+    def cleanup(
+        _span: Span, metadata_arg: MockMetadata, buffers: list[ChoiceBuffer]
+    ) -> None:
+        processed_buffers.extend(buffers)
+        assert metadata_arg == {"prompt_tokens": 10, "completion_tokens": 5}
+
+    cleanup_handler = Mock(side_effect=cleanup)
+
+    wrapper = AsyncStreamWrapper(span, stream, metadata, chunk_handler, cleanup_handler)
+
+    collected_chunks = []
+    async for chunk in wrapper:
+        collected_chunks.append(chunk)
+
+    assert collected_chunks == chunks
+    assert len(processed_buffers) == 1
+    buffer = processed_buffers[0]
+    assert (
+        buffer.index,
+        buffer.finish_reason,
+        buffer.text_content,
+        len(buffer.tool_calls_buffers),
+    ) == snapshot((0, "stop", ["Hello ", "async", "!"], 0))
+    assert metadata == {"prompt_tokens": 10, "completion_tokens": 5}
+
+    cleanup_handler.assert_called_once()
+    span.end.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_wrapper_iteration_with_exception() -> None:
+    span = Mock(spec=Span)
+
+    class AsyncStreamWithError(AsyncStreamProtocol[MockChunk]):
+        def __init__(self) -> None:
+            self._count = 0
+
+        def __aiter__(self) -> AsyncIterator[MockChunk]:
+            return self  # pragma: no cover
+
+        async def __anext__(self) -> MockChunk:
+            self._count += 1
+            if self._count == 1:
+                return MockChunk("chunk1")
+            else:
+                raise RuntimeError("Stream error")
+
+        async def aclose(self) -> None:
+            pass
+
+    stream = AsyncStreamWithError()
+
+    metadata = MockMetadata()
+    chunk_handler = Mock(spec=ChunkHandler)
+    cleanup_handler = Mock()
+
+    wrapper = AsyncStreamWrapper(span, stream, metadata, chunk_handler, cleanup_handler)
+
+    with pytest.raises(RuntimeError):
+        chunks = []
+        async for chunk in wrapper:
+            chunks.append(chunk)
+
+    span.set_status.assert_called_once()
+    status_call_args = span.set_status.call_args[0][0]
+    assert isinstance(status_call_args, Status)
+    assert status_call_args.status_code == StatusCode.ERROR
+    span.set_attribute.assert_called_once_with("error.type", "RuntimeError")
+    cleanup_handler.assert_called_once()
+    span.end.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_stream_wrapper_close() -> None:
+    span = Mock(spec=Span)
+    stream = Mock(spec=AsyncStreamProtocol)
+
+    metadata = MockMetadata()
+    chunk_handler = Mock(spec=ChunkHandler)
+    cleanup_handler = Mock()
+
+    wrapper = AsyncStreamWrapper(span, stream, metadata, chunk_handler, cleanup_handler)
+    await wrapper.close()
+
+    stream.aclose.assert_called_once()
+    cleanup_handler.assert_called_once()
+    span.end.assert_called_once()


### PR DESCRIPTION
### TL;DR

Added unit tests for OpenAI telemetry utilities in the Lilypad SDK.

### What changed?

This PR adds comprehensive unit tests for the OpenAI telemetry utilities in the Lilypad SDK. The tests cover:

- `StreamWrapper` and `AsyncStreamWrapper` classes for handling both synchronous and asynchronous OpenAI API response streams
- `OpenAIMetadata` and `OpenAIChunkHandler` for extracting and processing metadata from API responses
- Utility functions like `default_openai_cleanup`, `set_message_event`, `set_response_attributes`, `get_tool_calls`, and `get_choice_event`

The tests verify proper handling of various scenarios including:
- Normal streaming responses
- Error handling
- Context manager behavior
- Tool calls processing
- Different message formats and content types

### How to test?

Run the unit tests with pytest:

```bash
cd sdks/python
pytest tests/lilypad/_internal/otel/openai/test_utils.py -v
```

### Why make this change?

These tests ensure the reliability and correctness of the OpenAI telemetry utilities, which are critical for proper observability when using OpenAI's APIs through the Lilypad SDK. The tests cover edge cases and various response formats, helping to prevent regressions and ensure consistent behavior across different OpenAI API interactions.