### PR TITLE
fix: update OpenAI type definitions and null handling in instrumentation

### DIFF
--- a/.github/workflows/typescript-sdk-test.yml
+++ b/.github/workflows/typescript-sdk-test.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Build TypeScript
         run: npm run build
+#
 #      - name: Run tests with coverage
 #        run: npm run test:coverage
 #


### PR DESCRIPTION
### TL;DR

Improved OpenAI instrumentation by using proper type imports and adding null checks for parameters.

### What changed?

- Replaced direct OpenAI import with type imports to reduce bundle size
- Added proper type imports for `ChatCompletionCreateParamsBase` and `ChatCompletion` from OpenAI SDK
- Removed custom interface definitions in favor of using OpenAI's types
- Added null checks for all parameters to prevent errors when parameters are explicitly set to null
- Simplified message validation logic to be more permissive and compatible with OpenAI's API
- Fixed response format attribute handling to be more robust
- Improved type safety throughout the instrumentation code

### How to test?

1. Run the OpenAI instrumentation with various parameter combinations:
   - Test with parameters set to null
   - Test with different message formats
   - Test with streaming and non-streaming responses
2. Verify that telemetry spans are correctly created with appropriate attributes
3. Ensure that the instrumentation works with the latest OpenAI SDK version

### Why make this change?

The previous implementation had several issues:
1. It used custom interfaces instead of the types provided by the OpenAI SDK
2. It lacked null checks for parameters, which could cause errors
3. The message validation was too strict and didn't account for all valid message formats
4. The response format handling had edge cases that could cause errors

These changes make the instrumentation more robust, type-safe, and compatible with the OpenAI SDK's API.