### PR TITLE
test: add unit tests for SDK configuration and tracer functionality

### DIFF
--- a/.github/workflows/typescript-sdk-test.yml
+++ b/.github/workflows/typescript-sdk-test.yml
@@ -46,15 +46,15 @@ jobs:
 
       - name: Build TypeScript
         run: npm run build
-#
-#      - name: Run tests with coverage
-#        run: npm run test:coverage
-#
-#      - name: Upload coverage to Codecov
-#        uses: codecov/codecov-action@v3
-#        with:
-#          token: ${{ secrets.CODECOV_TOKEN }}
-#          directory: ./sdks/typescript/coverage
-#          flags: typescript-sdk
-#          name: typescript-sdk-node${{ matrix.node-version }}
-#          fail_ci_if_error: false
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./sdks/typescript/coverage
+          flags: typescript-sdk
+          name: typescript-sdk-node${{ matrix.node-version }}
+          fail_ci_if_error: false

--- a/sdks/typescript/src/configure.test.ts
+++ b/sdks/typescript/src/configure.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { trace } from '@opentelemetry/api';
+import {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { getTracer } from './configure';
+import { CryptoIdGenerator } from './utils/id-generator';
+
+vi.mock('@opentelemetry/sdk-trace-base', () => ({
+  ConsoleSpanExporter: vi.fn().mockImplementation(() => ({})),
+  SimpleSpanProcessor: vi.fn().mockImplementation(() => ({})),
+}));
+
+vi.mock('@opentelemetry/sdk-trace-node', () => ({
+  NodeTracerProvider: vi.fn().mockImplementation(() => ({
+    register: vi.fn(),
+  })),
+}));
+
+vi.mock('./utils/id-generator', () => ({
+  CryptoIdGenerator: vi.fn().mockImplementation(() => ({})),
+}));
+
+describe('configure', () => {
+  let consoleErrorSpy: any;
+  let consoleDebugSpy: any;
+  let moduleState: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.resetModules();
+    moduleState = await import('./configure');
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleDebugSpy.mockRestore();
+  });
+
+  it('should configure in debug mode', () => {
+    const mockRegister = vi.fn();
+    const MockNodeTracerProvider = vi.fn().mockImplementation(() => ({
+      register: mockRegister,
+    }));
+    vi.mocked(NodeTracerProvider).mockImplementation(MockNodeTracerProvider);
+
+    moduleState.configure({ mode: 'debug' });
+
+    expect(consoleDebugSpy).toHaveBeenCalledWith(
+      'Configuring lilypad SDK in debug mode.'
+    );
+    expect(ConsoleSpanExporter).toHaveBeenCalled();
+    expect(SimpleSpanProcessor).toHaveBeenCalled();
+    expect(CryptoIdGenerator).toHaveBeenCalled();
+    expect(NodeTracerProvider).toHaveBeenCalledWith({
+      idGenerator: expect.any(Object),
+      spanProcessors: [expect.any(Object)],
+    });
+    expect(mockRegister).toHaveBeenCalled();
+  });
+
+  it('should not configure if no mode is provided', () => {
+    moduleState.configure({});
+
+    expect(ConsoleSpanExporter).not.toHaveBeenCalled();
+    expect(SimpleSpanProcessor).not.toHaveBeenCalled();
+    expect(NodeTracerProvider).not.toHaveBeenCalled();
+  });
+
+  it('should not configure without config', () => {
+    moduleState.configure();
+
+    expect(ConsoleSpanExporter).not.toHaveBeenCalled();
+    expect(SimpleSpanProcessor).not.toHaveBeenCalled();
+    expect(NodeTracerProvider).not.toHaveBeenCalled();
+  });
+
+  it('should throw error for invalid mode', () => {
+    expect(() => moduleState.configure({ mode: 'invalid' as any })).toThrow(
+      "Invalid mode: invalid. Must be 'debug' or undefined."
+    );
+  });
+
+  it('should handle configuration errors', () => {
+    const mockError = new Error('Configuration failed');
+    vi.mocked(ConsoleSpanExporter).mockImplementationOnce(() => {
+      throw mockError;
+    });
+
+    expect(() => moduleState.configure({ mode: 'debug' })).toThrow(
+      'Failed to configure Lilypad SDK: Configuration failed'
+    );
+  });
+
+  it('should handle non-Error configuration errors', () => {
+    vi.mocked(ConsoleSpanExporter).mockImplementationOnce(() => {
+      throw 'String error';
+    });
+
+    expect(() => moduleState.configure({ mode: 'debug' })).toThrow(
+      'Failed to configure Lilypad SDK: String error'
+    );
+  });
+
+  it('should not reconfigure if already configured', async () => {
+    const mockRegister = vi.fn();
+    const MockNodeTracerProvider = vi.fn().mockImplementation(() => ({
+      register: mockRegister,
+    }));
+    vi.mocked(NodeTracerProvider).mockImplementation(MockNodeTracerProvider);
+
+    const freshModule = await import('./configure');
+    freshModule.configure({ mode: 'debug' });
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+
+    freshModule.configure({ mode: 'debug' });
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'TracerProvider already initialized.'
+    );
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('getTracer', () => {
+  it('should get tracer with default name', () => {
+    const mockGetTracer = vi.fn().mockReturnValue({});
+    trace.getTracer = mockGetTracer;
+
+    getTracer();
+
+    expect(mockGetTracer).toHaveBeenCalledWith('lilypad');
+  });
+
+  it('should get tracer with custom name', () => {
+    const mockGetTracer = vi.fn().mockReturnValue({});
+    trace.getTracer = mockGetTracer;
+
+    getTracer('custom-name');
+
+    expect(mockGetTracer).toHaveBeenCalledWith('custom-name');
+  });
+});


### PR DESCRIPTION
### TL;DR

Added unit tests for the SDK configuration module to ensure proper tracing setup.

### What changed?

Added a new test file `configure.test.ts` that thoroughly tests the SDK configuration functionality. The tests cover:

- Configuring the SDK in debug mode
- Handling cases with no mode or configuration
- Validating error handling for invalid modes
- Preventing reconfiguration when already initialized
- Testing the `getTracer` function with both default and custom names

The tests use Vitest and mock dependencies like OpenTelemetry's tracing components and the custom ID generator.

### How to test?

Run the test suite with:

```bash
cd sdks/typescript
npm test
```

Verify that all tests pass and provide adequate coverage for the configuration module.

### Why make this change?

These tests ensure the SDK configuration module works correctly, particularly the tracing setup which is critical for debugging and monitoring. The tests validate proper initialization of OpenTelemetry components, error handling, and prevention of duplicate configuration, improving the reliability of the SDK.