### PR TITLE
test: add TypeScript SDK export tests

### DIFF
--- a/sdks/typescript/src/index.test.ts
+++ b/sdks/typescript/src/index.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import lilypad, { configure, instrument_openai } from './index';
+import type { LilypadConfig } from './index';
+
+describe('index exports', () => {
+  it('should export default lilypad object', () => {
+    expect(lilypad).toBeDefined();
+    expect(lilypad.configure).toBeDefined();
+    expect(lilypad.instrument_openai).toBeDefined();
+    expect(typeof lilypad.configure).toBe('function');
+    expect(typeof lilypad.instrument_openai).toBe('function');
+  });
+
+  it('should export named functions', () => {
+    expect(configure).toBeDefined();
+    expect(instrument_openai).toBeDefined();
+    expect(typeof configure).toBe('function');
+    expect(typeof instrument_openai).toBe('function');
+  });
+
+  it('should export the same functions in default and named exports', () => {
+    expect(lilypad.configure).toBe(configure);
+    expect(lilypad.instrument_openai).toBe(instrument_openai);
+  });
+
+  it('should export LilypadConfig type', () => {
+    const config: LilypadConfig = { mode: 'debug' };
+    expect(config).toBeDefined();
+  });
+});


### PR DESCRIPTION
### TL;DR

Added unit tests for TypeScript SDK exports.

### What changed?

Added a new test file `index.test.ts` to verify the TypeScript SDK's exports. The tests ensure that:
- The default `lilypad` object is properly exported with its methods
- Named exports (`configure` and `instrument_openai`) are available
- Default and named exports reference the same functions
- Type definitions like `LilypadConfig` are properly exported

### How to test?

Run the test suite in the TypeScript SDK:
```bash
cd sdks/typescript
npm test
```

### Why make this change?

To ensure the TypeScript SDK maintains a consistent public API and that all expected exports are available to consumers. This helps prevent accidental breaking changes to the SDK's interface during future development.