### PR TITLE
fix: implement temporary API keys for playground execution

### DIFF
--- a/app/lilypad/server/_utils/auth.py
+++ b/app/lilypad/server/_utils/auth.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import secrets
 from collections.abc import Callable, Coroutine
+from datetime import datetime, timezone
 from typing import Annotated, Any
 from uuid import UUID
 
@@ -122,6 +123,14 @@ async def get_current_user(
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user"
             )
+
+        if api_key_row.expires_at and api_key_row.expires_at < datetime.now(
+            timezone.utc
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="API key has expired"
+            )
+
         user_public = UserPublic.model_validate(api_key_row.user)
         user_public.scopes = DEFAULT_SCOPES  # type: ignore[misc]
         request.state.user = user_public

--- a/app/lilypad/server/_utils/versions.py
+++ b/app/lilypad/server/_utils/versions.py
@@ -13,7 +13,7 @@ def construct_function(
     import_line = "import lilypad" if include_import else ""
     func_def = f"""
     {import_line}
-    @lilypad.function(managed=True)
-    def {function_name}({", ".join(arg_list)}) -> lilypad.Message: ...
+    @lilypad.trace(versioning="automatic")
+    def {function_name}({", ".join(arg_list)}): ...
     """
     return run_ruff(dedent(func_def)).strip()

--- a/app/lilypad/server/api/v0/spans_api.py
+++ b/app/lilypad/server/api/v0/spans_api.py
@@ -78,7 +78,7 @@ async def get_span(
     project_uuid: UUID,
     span_identifier: str,
     span_service: Annotated[SpanService, Depends(SpanService)],
-    environment_uuid: Annotated[UUID, Query()],
+    environment_uuid: Annotated[UUID | None, Query()] = None,
 ) -> SpanMoreDetails:
     """Get span by uuid or span_id."""
     # Try to parse as UUID first

--- a/app/lilypad/server/api/v0/traces_api.py
+++ b/app/lilypad/server/api/v0/traces_api.py
@@ -190,7 +190,10 @@ async def traces(
         if "attributes" not in trace:
             trace["attributes"] = {}
         trace["attributes"]["lilypad.project.uuid"] = str(project_uuid)
-        trace["attributes"]["lilypad.environment.uuid"] = str(api_key.environment_uuid)
+        if api_key.environment_uuid:
+            trace["attributes"]["lilypad.environment.uuid"] = str(
+                api_key.environment_uuid
+            )
 
     # Extract unique trace IDs from spans
     trace_ids = list(

--- a/app/playground-requirements.lock
+++ b/app/playground-requirements.lock
@@ -161,13 +161,13 @@ jsonschema-specifications==2024.10.1
     # via jsonschema
 libcst==1.7.0
     # via lilypad-sdk
-lilypad-sdk==0.1.0a14
+lilypad-sdk==0.10.3
     # via -r playground-requirements.txt
 litellm==1.65.1
     # via mirascope
 markupsafe==3.0.2
     # via jinja2
-mirascope==1.22.2
+mirascope==1.25.5
     # via
     #   -r playground-requirements.txt
     #   lilypad-sdk
@@ -191,9 +191,15 @@ opentelemetry-api==1.31.1
     # via
     #   lilypad-sdk
     #   opentelemetry-instrumentation
+    #   opentelemetry-propagator-b3
+    #   opentelemetry-propagator-jaeger
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-instrumentation==0.52b1
+    # via lilypad-sdk
+opentelemetry-propagator-b3==1.36.0
+    # via lilypad-sdk
+opentelemetry-propagator-jaeger==1.36.0
     # via lilypad-sdk
 opentelemetry-sdk==1.31.1
     # via lilypad-sdk
@@ -201,6 +207,8 @@ opentelemetry-semantic-conventions==0.52b1
     # via
     #   opentelemetry-instrumentation
     #   opentelemetry-sdk
+orjson==3.11.1
+    # via lilypad-sdk
 packaging==24.2
     # via
     #   huggingface-hub
@@ -214,7 +222,9 @@ propcache==0.3.1
     #   aiohttp
     #   yarl
 proto-plus==1.26.1
-    # via mirascope
+    # via
+    #   lilypad-sdk
+    #   mirascope
 protobuf==6.30.2
     # via proto-plus
 pyasn1==0.6.1
@@ -330,6 +340,7 @@ typing-extensions==4.13.0
     #   multidict
     #   mypy-boto3-bedrock-runtime
     #   openai
+    #   opentelemetry-propagator-b3
     #   opentelemetry-sdk
     #   pydantic
     #   pydantic-core

--- a/app/playground-requirements.txt
+++ b/app/playground-requirements.txt
@@ -1,2 +1,2 @@
-lilypad-sdk[openai,anthropic,azure,bedrock,google,mistral]==0.1.0a14
-mirascope[anthropic,azure,bedrock,cohere,google,groq,litellm,mistral,openai,xai]==1.22.2
+lilypad-sdk[openai,anthropic,azure,bedrock,google,mistral]==0.10.3
+mirascope[anthropic,azure,bedrock,cohere,google,groq,litellm,mistral,openai,xai]==1.25.5

--- a/app/tests/ee/server/api/v0/test_ee_functions_api.py
+++ b/app/tests/ee/server/api/v0/test_ee_functions_api.py
@@ -932,6 +932,9 @@ def test_playground_api_success_without_span_id():
             mock_api_key_service.find_keys_by_user_and_project.return_value = [
                 mock_api_key
             ]
+            mock_api_key_service.user.uuid = uuid4()
+            mock_api_key_service.user.active_organization_uuid = uuid4()
+            mock_api_key_service.session = Mock()
             mock_user_external_api_key_service = Mock()
             mock_user_external_api_key_service.list_api_keys.return_value = {
                 "openai": "test"
@@ -996,6 +999,9 @@ def test_playground_api_invalid_error_structure():
             mock_api_key_service.find_keys_by_user_and_project.return_value = [
                 mock_api_key
             ]
+            mock_api_key_service.user.uuid = uuid4()
+            mock_api_key_service.user.active_organization_uuid = uuid4()
+            mock_api_key_service.session = Mock()
             mock_user_external_api_key_service = Mock()
             mock_user_external_api_key_service.list_api_keys.return_value = {
                 "openai": "test"
@@ -1066,6 +1072,9 @@ def test_playground_api_timeout_error():
             mock_api_key_service.find_keys_by_user_and_project.return_value = [
                 mock_api_key
             ]
+            mock_api_key_service.user.uuid = uuid4()
+            mock_api_key_service.user.active_organization_uuid = uuid4()
+            mock_api_key_service.session = Mock()
             mock_user_external_api_key_service = Mock()
             mock_user_external_api_key_service.list_api_keys.return_value = {
                 "openai": "test"
@@ -1135,6 +1144,9 @@ def test_playground_api_configuration_error():
             mock_api_key_service.find_keys_by_user_and_project.return_value = [
                 mock_api_key
             ]
+            mock_api_key_service.user.uuid = uuid4()
+            mock_api_key_service.user.active_organization_uuid = uuid4()
+            mock_api_key_service.session = Mock()
             mock_user_external_api_key_service = Mock()
             mock_user_external_api_key_service.list_api_keys.return_value = {
                 "openai": "test"

--- a/app/tests/server/_utils/test_versions.py
+++ b/app/tests/server/_utils/test_versions.py
@@ -7,7 +7,7 @@ def test_construct_function():
     function_name = "test_function"
 
     code = construct_function(arg_types, function_name)
-    assert "@lilypad.function(managed=True)" in code
+    assert '@lilypad.trace(versioning="automatic")' in code
     assert "def test_function(text: str, temperature: float)" in code
 
 
@@ -18,12 +18,12 @@ def test_construct_function_with_configure():
 
     code = construct_function(arg_types, function_name, include_import=True)
     assert "import lilypad" in code
-    assert "@lilypad.function(managed=True)" in code
+    assert '@lilypad.trace(versioning="automatic")' in code
     assert "def test_function(text: str)" in code
 
 
 def test_construct_function_no_args():
     """Test constructing function with no arguments"""
     code = construct_function({}, "test_function")
-    assert "@lilypad.function(managed=True)" in code
+    assert '@lilypad.trace(versioning="automatic")' in code
     assert "def test_function()" in code

--- a/sdks/fern/lilypad-api.json
+++ b/sdks/fern/lilypad-api.json
@@ -545,6 +545,23 @@
               "format": "uuid",
               "title": "Function Uuid"
             }
+          },
+          {
+            "name": "environment_uuid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Environment Uuid"
+            }
           }
         ],
         "requestBody": {
@@ -2520,10 +2537,17 @@
           {
             "name": "environment_uuid",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "string",
-              "format": "uuid",
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                {
+                  "type": "null"
+                }
+              ],
               "title": "Environment Uuid"
             }
           }

--- a/sdks/python/src/lilypad/generated/client.py
+++ b/sdks/python/src/lilypad/generated/client.py
@@ -206,7 +206,7 @@ class Lilypad:
         project_uuid: str,
         span_identifier: str,
         *,
-        environment_uuid: str,
+        environment_uuid: typing.Optional[str] = None,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> SpanMoreDetails:
         """
@@ -218,7 +218,7 @@ class Lilypad:
 
         span_identifier : str
 
-        environment_uuid : str
+        environment_uuid : typing.Optional[str]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -240,7 +240,6 @@ class Lilypad:
         client.get_span_projects_project_uuid_spans_span_identifier_get(
             project_uuid="project_uuid",
             span_identifier="span_identifier",
-            environment_uuid="environment_uuid",
         )
         """
         _response = self._raw_client.get_span_projects_project_uuid_spans_span_identifier_get(
@@ -501,7 +500,7 @@ class AsyncLilypad:
         project_uuid: str,
         span_identifier: str,
         *,
-        environment_uuid: str,
+        environment_uuid: typing.Optional[str] = None,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> SpanMoreDetails:
         """
@@ -513,7 +512,7 @@ class AsyncLilypad:
 
         span_identifier : str
 
-        environment_uuid : str
+        environment_uuid : typing.Optional[str]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -540,7 +539,6 @@ class AsyncLilypad:
             await client.get_span_projects_project_uuid_spans_span_identifier_get(
                 project_uuid="project_uuid",
                 span_identifier="span_identifier",
-                environment_uuid="environment_uuid",
             )
 
 

--- a/sdks/python/src/lilypad/generated/ee/projects/functions/client.py
+++ b/sdks/python/src/lilypad/generated/ee/projects/functions/client.py
@@ -40,6 +40,7 @@ class FunctionsClient:
         provider: Provider,
         model: str,
         prompt_template: str,
+        environment_uuid: typing.Optional[str] = None,
         arg_types: typing.Optional[typing.Dict[str, typing.Optional[str]]] = OMIT,
         call_params: typing.Optional[CommonCallParams] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
@@ -60,6 +61,8 @@ class FunctionsClient:
         model : str
 
         prompt_template : str
+
+        environment_uuid : typing.Optional[str]
 
         arg_types : typing.Optional[typing.Dict[str, typing.Optional[str]]]
 
@@ -98,6 +101,7 @@ class FunctionsClient:
             provider=provider,
             model=model,
             prompt_template=prompt_template,
+            environment_uuid=environment_uuid,
             arg_types=arg_types,
             call_params=call_params,
             request_options=request_options,
@@ -130,6 +134,7 @@ class AsyncFunctionsClient:
         provider: Provider,
         model: str,
         prompt_template: str,
+        environment_uuid: typing.Optional[str] = None,
         arg_types: typing.Optional[typing.Dict[str, typing.Optional[str]]] = OMIT,
         call_params: typing.Optional[CommonCallParams] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
@@ -150,6 +155,8 @@ class AsyncFunctionsClient:
         model : str
 
         prompt_template : str
+
+        environment_uuid : typing.Optional[str]
 
         arg_types : typing.Optional[typing.Dict[str, typing.Optional[str]]]
 
@@ -196,6 +203,7 @@ class AsyncFunctionsClient:
             provider=provider,
             model=model,
             prompt_template=prompt_template,
+            environment_uuid=environment_uuid,
             arg_types=arg_types,
             call_params=call_params,
             request_options=request_options,

--- a/sdks/python/src/lilypad/generated/ee/projects/functions/raw_client.py
+++ b/sdks/python/src/lilypad/generated/ee/projects/functions/raw_client.py
@@ -39,6 +39,7 @@ class RawFunctionsClient:
         provider: Provider,
         model: str,
         prompt_template: str,
+        environment_uuid: typing.Optional[str] = None,
         arg_types: typing.Optional[typing.Dict[str, typing.Optional[str]]] = OMIT,
         call_params: typing.Optional[CommonCallParams] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
@@ -60,6 +61,8 @@ class RawFunctionsClient:
 
         prompt_template : str
 
+        environment_uuid : typing.Optional[str]
+
         arg_types : typing.Optional[typing.Dict[str, typing.Optional[str]]]
 
         call_params : typing.Optional[CommonCallParams]
@@ -75,6 +78,9 @@ class RawFunctionsClient:
         _response = self._client_wrapper.httpx_client.request(
             f"ee/projects/{jsonable_encoder(project_uuid)}/functions/{jsonable_encoder(function_uuid)}/playground",
             method="POST",
+            params={
+                "environment_uuid": environment_uuid,
+            },
             json={
                 "arg_values": convert_and_respect_annotation_metadata(
                     object_=arg_values,
@@ -179,6 +185,7 @@ class AsyncRawFunctionsClient:
         provider: Provider,
         model: str,
         prompt_template: str,
+        environment_uuid: typing.Optional[str] = None,
         arg_types: typing.Optional[typing.Dict[str, typing.Optional[str]]] = OMIT,
         call_params: typing.Optional[CommonCallParams] = OMIT,
         request_options: typing.Optional[RequestOptions] = None,
@@ -200,6 +207,8 @@ class AsyncRawFunctionsClient:
 
         prompt_template : str
 
+        environment_uuid : typing.Optional[str]
+
         arg_types : typing.Optional[typing.Dict[str, typing.Optional[str]]]
 
         call_params : typing.Optional[CommonCallParams]
@@ -215,6 +224,9 @@ class AsyncRawFunctionsClient:
         _response = await self._client_wrapper.httpx_client.request(
             f"ee/projects/{jsonable_encoder(project_uuid)}/functions/{jsonable_encoder(function_uuid)}/playground",
             method="POST",
+            params={
+                "environment_uuid": environment_uuid,
+            },
             json={
                 "arg_values": convert_and_respect_annotation_metadata(
                     object_=arg_values,

--- a/sdks/python/src/lilypad/generated/raw_client.py
+++ b/sdks/python/src/lilypad/generated/raw_client.py
@@ -151,7 +151,7 @@ class RawLilypad:
         project_uuid: str,
         span_identifier: str,
         *,
-        environment_uuid: str,
+        environment_uuid: typing.Optional[str] = None,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[SpanMoreDetails]:
         """
@@ -163,7 +163,7 @@ class RawLilypad:
 
         span_identifier : str
 
-        environment_uuid : str
+        environment_uuid : typing.Optional[str]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -400,7 +400,7 @@ class AsyncRawLilypad:
         project_uuid: str,
         span_identifier: str,
         *,
-        environment_uuid: str,
+        environment_uuid: typing.Optional[str] = None,
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[SpanMoreDetails]:
         """
@@ -412,7 +412,7 @@ class AsyncRawLilypad:
 
         span_identifier : str
 
-        environment_uuid : str
+        environment_uuid : typing.Optional[str]
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.

--- a/sdks/python/src/lilypad/generated/reference.md
+++ b/sdks/python/src/lilypad/generated/reference.md
@@ -190,7 +190,6 @@ client = Lilypad(
 client.get_span_projects_project_uuid_spans_span_identifier_get(
     project_uuid="project_uuid",
     span_identifier="span_identifier",
-    environment_uuid="environment_uuid",
 )
 
 ```
@@ -223,7 +222,7 @@ client.get_span_projects_project_uuid_spans_span_identifier_get(
 <dl>
 <dd>
 
-**environment_uuid:** `str` 
+**environment_uuid:** `typing.Optional[str]` 
     
 </dd>
 </dl>
@@ -4313,6 +4312,14 @@ client.ee.projects.functions.run_playground(
 <dd>
 
 **prompt_template:** `str` 
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**environment_uuid:** `typing.Optional[str]` 
     
 </dd>
 </dl>


### PR DESCRIPTION
### TL;DR

Improved playground function execution with temporary API keys, better error handling, and updated SDK dependencies.

### What changed?

- Added temporary API key creation for playground function execution that expires after 5 minutes
- Added support for environment-specific playground execution via a new `environment_uuid` query parameter
- Improved error handling and result parsing in playground function execution
- Enhanced span retrieval with retries to handle potential race conditions
- Updated SDK dependencies to newer versions (lilypad-sdk 0.10.3, mirascope 1.25.5)
- Modified function wrapper code to better handle different response types
- Added API key expiration check in authentication flow
- Updated function template to use `@lilypad.trace` instead of `@lilypad.function`

### How to test?

1. Run playground functions with and without specifying an environment UUID
2. Test playground functions that return different response types
3. Verify that temporary API keys are created and deleted properly
4. Check that expired API keys are rejected during authentication
5. Verify that spans are correctly associated with playground executions

### Why make this change?

This change improves security by using short-lived API keys for playground executions instead of reusing existing keys. It also adds environment-specific execution capabilities, making the playground more flexible for testing across different environments. The improved error handling and response parsing makes the playground more robust when dealing with various function return types, while the retry mechanism helps ensure spans are properly captured even with potential race conditions.