### PR TITLE
Port Anthropic OpenTelemetry into Lilypad v1

### DIFF
--- a/sdks/python/examples/instrument_anthropic_with_console.py
+++ b/sdks/python/examples/instrument_anthropic_with_console.py
@@ -1,0 +1,28 @@
+import lilypad
+from anthropic import Anthropic
+from anthropic.types import TextBlock
+from opentelemetry import trace
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.sdk.trace import TracerProvider
+
+# Export spans to the console.
+otlp_exporter = ConsoleSpanExporter()
+processor = SimpleSpanProcessor(otlp_exporter)
+provider = TracerProvider(id_generator=lilypad.configuration.CryptoIdGenerator())
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+
+lilypad.configure()  # will log that a tracer has already been configured, which is ok
+
+client = Anthropic()
+lilypad.instrument_anthropic(client)
+
+message = client.messages.create(
+    model="claude-3-haiku-20240307",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello! How are you?"}],
+)
+if (content := message.content) and isinstance(content[0], TextBlock):
+    print(content[0].text)
+else:
+    print("No content found.")

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 openai = ["openai>=1.98.0"]
+anthropic = ["anthropic>=0.63.0"]
 
 [dependency-groups]
 dev = ["pyright>=1.1.403", "ruff>=0.12.7", "pre-commit>=3.5.0"]
@@ -43,7 +44,7 @@ test = [
     "inline-snapshot>=0.23.0",
     "python-dotenv>=1.1.1",
 ]
-examples = ["openai>=1.98.0"]
+examples = ["openai>=1.98.0", "anthropic>=0.63.0"]
 
 [build-system]
 requires = ["uv_build>=0.8.4,<0.9.0"]

--- a/sdks/python/src/lilypad/__init__.py
+++ b/sdks/python/src/lilypad/__init__.py
@@ -1,7 +1,14 @@
 """Lilypad SDK - The official Python library for the Lilypad API."""
 
+from contextlib import suppress
+
 from . import configuration
 from .configuration import configure
-from ._internal.otel import instrument_openai
 
-__all__ = ["configuration", "configure", "instrument_openai"]
+with suppress(ImportError):
+    from ._internal.otel import instrument_openai
+
+with suppress(ImportError):
+    from ._internal.otel import instrument_anthropic
+
+__all__ = ["configuration", "configure", "instrument_anthropic", "instrument_openai"]

--- a/sdks/python/src/lilypad/_internal/otel/__init__.py
+++ b/sdks/python/src/lilypad/_internal/otel/__init__.py
@@ -5,6 +5,10 @@ from contextlib import suppress
 with suppress(ImportError):
     from .openai import instrument_openai as instrument_openai
 
+with suppress(ImportError):
+    from .anthropic import instrument_anthropic as instrument_anthropic
+
 __all__ = [
+    "instrument_anthropic",
     "instrument_openai",
 ]

--- a/sdks/python/src/lilypad/_internal/otel/anthropic/__init__.py
+++ b/sdks/python/src/lilypad/_internal/otel/anthropic/__init__.py
@@ -1,0 +1,5 @@
+"""Anthropic OpenTelemetry instrumentation module."""
+
+from .instrument import instrument_anthropic
+
+__all__ = ["instrument_anthropic"]

--- a/sdks/python/src/lilypad/_internal/otel/anthropic/_patch.py
+++ b/sdks/python/src/lilypad/_internal/otel/anthropic/_patch.py
@@ -1,0 +1,306 @@
+"""Patching utilities for Anthropic client methods to add OpenTelemetry instrumentation.
+
+This module contains the core logic for wrapping Anthropic API calls with telemetry spans.
+"""
+
+from typing import (
+    Any,
+    Literal,
+    Protocol,
+    ParamSpec,
+    cast,
+    overload,
+)
+from contextlib import contextmanager
+from collections.abc import Callable, Iterator, Awaitable
+
+from anthropic import Anthropic, AsyncAnthropic
+from anthropic.types import Message, MessageStreamEvent
+from opentelemetry.trace import Span, Status, Tracer, SpanKind, StatusCode
+from opentelemetry.semconv.attributes import error_attributes
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes,
+)
+
+from . import _utils
+from ..utils import (
+    StreamWrapper,
+    StreamProtocol,
+    AsyncStreamWrapper,
+    AsyncStreamProtocol,
+)
+
+P = ParamSpec("P")
+
+
+class SyncCompletionHandler(Protocol[P]):
+    """Protocol for sync non-streaming handler."""
+
+    def __call__(
+        self,
+        wrapped: Callable[P, Message],
+        client: Anthropic,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Message: ...
+
+
+class SyncStreamHandler(Protocol[P]):
+    """Protocol for sync streaming handler."""
+
+    def __call__(
+        self,
+        wrapped: Callable[P, StreamProtocol[MessageStreamEvent]],
+        client: Anthropic,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> StreamWrapper[MessageStreamEvent, _utils.AnthropicMetadata]: ...
+
+
+class AsyncCompletionHandler(Protocol[P]):
+    """Protocol for async non-streaming handler."""
+
+    async def __call__(
+        self,
+        wrapped: Callable[P, Awaitable[Message]],
+        client: AsyncAnthropic,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> Message: ...
+
+
+class AsyncStreamHandler(Protocol[P]):
+    """Protocol for async streaming handler."""
+
+    async def __call__(
+        self,
+        wrapped: Callable[P, Awaitable[AsyncStreamProtocol[MessageStreamEvent]]],
+        client: AsyncAnthropic,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ) -> AsyncStreamWrapper[MessageStreamEvent, _utils.AnthropicMetadata]: ...
+
+
+@contextmanager
+def _span(
+    tracer: Tracer, kwargs: dict[str, Any], client: Anthropic | AsyncAnthropic
+) -> Iterator[Span]:
+    """Context manager for creating and managing OpenTelemetry spans."""
+    span_attributes = {**_utils.get_llm_request_attributes(kwargs, client)}
+    span_name = f"{span_attributes[gen_ai_attributes.GEN_AI_OPERATION_NAME]} {span_attributes.get(gen_ai_attributes.GEN_AI_REQUEST_MODEL, 'unknown')}"
+
+    with tracer.start_as_current_span(
+        name=span_name,
+        kind=SpanKind.CLIENT,
+        attributes=span_attributes,
+        end_on_exit=False,
+    ) as span:
+        yield span
+
+
+@overload
+def _sync_wrapper(
+    tracer: Tracer, handle_stream: Literal[False]
+) -> SyncCompletionHandler[P]: ...
+
+
+@overload
+def _sync_wrapper(
+    tracer: Tracer, handle_stream: Literal[True]
+) -> SyncStreamHandler[P]: ...
+
+
+def _sync_wrapper(
+    tracer: Tracer, handle_stream: bool
+) -> SyncCompletionHandler[P] | SyncStreamHandler[P]:
+    """Internal sync wrapper for Anthropic API calls."""
+
+    if not handle_stream:
+
+        def traced_method_completion(
+            wrapped: Callable[P, Message],
+            client: Anthropic,
+            args: tuple[Any, ...],
+            kwargs: dict[str, Any],
+        ) -> Message:
+            with _span(tracer, kwargs, client) as span:
+                if span.is_recording():
+                    for message in kwargs.get("messages", []):
+                        _utils.set_message_event(span, message)
+                    if system := kwargs.get("system"):
+                        _utils.set_message_event(
+                            span,
+                            _utils.SystemMessageParam(role="system", content=system),
+                        )
+                try:
+                    result = wrapped(*args, **kwargs)
+                    if span.is_recording():
+                        _utils.set_response_attributes(span, result)
+                    span.end()
+                    return result
+                except Exception as error:
+                    span.set_status(Status(StatusCode.ERROR, str(error)))
+                    if span.is_recording():
+                        span.set_attribute(
+                            error_attributes.ERROR_TYPE, type(error).__qualname__
+                        )
+                    span.end()
+                    raise
+
+        return traced_method_completion
+    else:
+
+        def traced_method_stream(
+            wrapped: Callable[P, StreamProtocol[MessageStreamEvent]],
+            client: Anthropic,
+            args: tuple[Any, ...],
+            kwargs: dict[str, Any],
+        ) -> StreamWrapper[MessageStreamEvent, _utils.AnthropicMetadata]:
+            with _span(tracer, kwargs, client) as span:
+                if span.is_recording():
+                    for message in kwargs.get("messages", []):
+                        _utils.set_message_event(span, message)
+                    if system := kwargs.get("system"):
+                        _utils.set_message_event(
+                            span,
+                            _utils.SystemMessageParam(role="system", content=system),
+                        )
+                try:
+                    if kwargs.get("stream", False):
+                        return StreamWrapper(
+                            span=span,
+                            stream=wrapped(*args, **kwargs),
+                            metadata=_utils.AnthropicMetadata(),
+                            chunk_handler=_utils.AnthropicChunkHandler(),
+                            cleanup_handler=_utils.default_anthropic_cleanup,
+                        )
+                    result = cast(Message, wrapped(*args, **kwargs))
+                    if span.is_recording():
+                        _utils.set_response_attributes(span, result)
+                    span.end()
+                    return cast(
+                        StreamWrapper[MessageStreamEvent, _utils.AnthropicMetadata],
+                        result,
+                    )
+                except Exception as error:
+                    span.set_status(Status(StatusCode.ERROR, str(error)))
+                    if span.is_recording():
+                        span.set_attribute(
+                            error_attributes.ERROR_TYPE, type(error).__qualname__
+                        )
+                    span.end()
+                    raise
+
+        return traced_method_stream
+
+
+@overload
+def _async_wrapper(
+    tracer: Tracer, handle_stream: Literal[False]
+) -> AsyncCompletionHandler[P]: ...
+
+
+@overload
+def _async_wrapper(
+    tracer: Tracer, handle_stream: Literal[True]
+) -> AsyncStreamHandler[P]: ...
+
+
+def _async_wrapper(
+    tracer: Tracer, handle_stream: bool
+) -> AsyncCompletionHandler[P] | AsyncStreamHandler[P]:
+    """Internal async wrapper for Anthropic API calls."""
+
+    if not handle_stream:
+
+        async def traced_method_completion(
+            wrapped: Callable[P, Awaitable[Message]],
+            client: AsyncAnthropic,
+            args: tuple[Any, ...],
+            kwargs: dict[str, Any],
+        ) -> Message:
+            with _span(tracer, kwargs, client) as span:
+                if span.is_recording():
+                    for message in kwargs.get("messages", []):
+                        _utils.set_message_event(span, message)
+                    if system := kwargs.get("system"):
+                        _utils.set_message_event(
+                            span,
+                            _utils.SystemMessageParam(role="system", content=system),
+                        )
+                try:
+                    result = await wrapped(*args, **kwargs)
+                    if span.is_recording():
+                        _utils.set_response_attributes(span, result)
+                    span.end()
+                    return result
+                except Exception as error:
+                    span.set_status(Status(StatusCode.ERROR, str(error)))
+                    if span.is_recording():
+                        span.set_attribute(
+                            error_attributes.ERROR_TYPE, type(error).__qualname__
+                        )
+                    span.end()
+                    raise
+
+        return traced_method_completion
+    else:
+
+        async def traced_method_stream(
+            wrapped: Callable[P, Awaitable[AsyncStreamProtocol[MessageStreamEvent]]],
+            client: AsyncAnthropic,
+            args: tuple[Any, ...],
+            kwargs: dict[str, Any],
+        ) -> AsyncStreamWrapper[MessageStreamEvent, _utils.AnthropicMetadata]:
+            with _span(tracer, kwargs, client) as span:
+                if span.is_recording():
+                    for message in kwargs.get("messages", []):
+                        _utils.set_message_event(span, message)
+                    if system := kwargs.get("system"):
+                        _utils.set_message_event(
+                            span,
+                            _utils.SystemMessageParam(role="system", content=system),
+                        )
+                try:
+                    if kwargs.get("stream", False):
+                        return AsyncStreamWrapper(
+                            span=span,
+                            stream=await wrapped(*args, **kwargs),
+                            metadata=_utils.AnthropicMetadata(),
+                            chunk_handler=_utils.AnthropicChunkHandler(),
+                            cleanup_handler=_utils.default_anthropic_cleanup,
+                        )
+                    result = cast(Message, await wrapped(*args, **kwargs))
+                    if span.is_recording():
+                        _utils.set_response_attributes(span, result)
+                    span.end()
+                    return cast(
+                        AsyncStreamWrapper[
+                            MessageStreamEvent, _utils.AnthropicMetadata
+                        ],
+                        result,
+                    )
+                except Exception as error:
+                    span.set_status(Status(StatusCode.ERROR, str(error)))
+                    if span.is_recording():
+                        span.set_attribute(
+                            error_attributes.ERROR_TYPE, type(error).__qualname__
+                        )
+                    span.end()
+                    raise
+
+        return traced_method_stream
+
+
+def messages_create_patch_factory(
+    tracer: Tracer,
+) -> SyncStreamHandler[P]:
+    """Returns a patch factory for sync messages create method."""
+    return _sync_wrapper(tracer, handle_stream=True)
+
+
+def messages_create_async_patch_factory(
+    tracer: Tracer,
+) -> AsyncStreamHandler[P]:
+    """Returns a patch factory for async messages create method."""
+    return _async_wrapper(tracer, handle_stream=True)

--- a/sdks/python/src/lilypad/_internal/otel/anthropic/_utils.py
+++ b/sdks/python/src/lilypad/_internal/otel/anthropic/_utils.py
@@ -1,0 +1,298 @@
+"""Utility functions for Anthropic OpenTelemetry instrumentation.
+
+This module provides helper functions for extracting and formatting Anthropic API
+response data for telemetry purposes.
+"""
+
+import json
+from typing import Any, Literal, Iterable, TypedDict
+
+from anthropic.types import (
+    Message,
+    TextBlock,
+    ContentBlock,
+    MessageParam,
+    ToolUseBlock,
+    TextBlockParam,
+    MessageStreamEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+)
+from opentelemetry.trace import Span
+from opentelemetry.util.types import AttributeValue
+from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
+
+from ..types import LLMOpenTelemetryMessage, LLMOpenTelemetryToolCall
+from ..utils import (
+    BaseMetadata,
+    ChoiceBuffer,
+    ChunkHandler,
+    ToolCallBuffer,
+    set_server_address_and_port,
+)
+from ...utils import json_dumps
+
+
+class AnthropicMetadata(BaseMetadata, total=False):
+    """Anthropic-specific metadata extending BaseMetadata."""
+
+    stop_reason: str | None
+
+
+class AnthropicChunkHandler(ChunkHandler[MessageStreamEvent, AnthropicMetadata]):
+    def extract_metadata(
+        self, chunk: MessageStreamEvent, metadata: AnthropicMetadata
+    ) -> None:
+        """Extract metadata from a streaming chunk and update the metadata dictionary."""
+        if isinstance(chunk, RawMessageStartEvent):
+            message = chunk.message
+            if not metadata.get("response_model"):
+                metadata["response_model"] = message.model
+            if not metadata.get("response_id"):
+                metadata["response_id"] = message.id
+            if message.usage:
+                metadata["prompt_tokens"] = message.usage.input_tokens
+                metadata["completion_tokens"] = message.usage.output_tokens
+
+        elif isinstance(chunk, RawMessageDeltaEvent):
+            if chunk.delta.stop_reason:
+                metadata["stop_reason"] = chunk.delta.stop_reason
+            if chunk.usage:
+                metadata["completion_tokens"] = chunk.usage.output_tokens
+
+    def process_chunk(
+        self, chunk: MessageStreamEvent, buffers: list[ChoiceBuffer]
+    ) -> None:
+        """Process a streaming chunk and update the choice buffers with content."""
+
+        if isinstance(chunk, RawContentBlockStartEvent):
+            while len(buffers) <= chunk.index:
+                buffers.append(ChoiceBuffer(len(buffers)))
+
+            content_block = chunk.content_block
+            if isinstance(content_block, ToolUseBlock):
+                buffer = buffers[chunk.index]
+
+                if not buffer.tool_calls_buffers:
+                    buffer.tool_calls_buffers.append(
+                        ToolCallBuffer(
+                            chunk.index,
+                            content_block.id,
+                            content_block.name,
+                        )
+                    )
+
+        elif isinstance(chunk, RawContentBlockDeltaEvent):
+            while len(buffers) <= chunk.index:
+                buffers.append(ChoiceBuffer(len(buffers)))
+
+            if chunk.delta.type == "text_delta":
+                buffers[chunk.index].append_text_content(chunk.delta.text)
+            elif chunk.delta.type == "input_json_delta":
+                if chunk.index < len(buffers):
+                    buffer = buffers[chunk.index]
+                    if not buffer.tool_calls_buffers:
+                        buffer.tool_calls_buffers.append(None)
+                    if buffer.tool_calls_buffers[0]:
+                        buffer.tool_calls_buffers[0].append_arguments(
+                            chunk.delta.partial_json
+                        )
+                    else:
+                        buffer.tool_calls_buffers[0] = ToolCallBuffer(
+                            chunk.index, "", ""
+                        )
+
+        elif isinstance(chunk, RawMessageDeltaEvent):
+            if chunk.delta.stop_reason:
+                for buffer in buffers:
+                    buffer.finish_reason = chunk.delta.stop_reason
+
+
+def default_anthropic_cleanup(
+    span: Span, metadata: AnthropicMetadata, buffers: list[ChoiceBuffer]
+) -> None:
+    """Set final span attributes and events from accumulated metadata and buffers."""
+    attributes = {}
+    if response_model := metadata.get("response_model"):
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_MODEL] = response_model
+    if response_id := metadata.get("response_id"):
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_ID] = response_id
+    if prompt_tokens := metadata.get("prompt_tokens"):
+        attributes[gen_ai_attributes.GEN_AI_USAGE_INPUT_TOKENS] = prompt_tokens
+    if completion_tokens := metadata.get("completion_tokens"):
+        attributes[gen_ai_attributes.GEN_AI_USAGE_OUTPUT_TOKENS] = completion_tokens
+
+    if stop_reason := metadata.get("stop_reason"):
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_FINISH_REASONS] = [stop_reason]
+    elif finish_reasons := tuple(
+        buffer.finish_reason for buffer in buffers if buffer.finish_reason is not None
+    ):
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_FINISH_REASONS] = finish_reasons
+
+    span.set_attributes(attributes)
+    for index, choice in enumerate(buffers):
+        message: LLMOpenTelemetryMessage = {"role": "assistant"}
+        if choice.text_content:
+            message["content"] = "".join(choice.text_content)
+        if choice.tool_calls_buffers:
+            tool_calls = []
+            for tool_call in choice.tool_calls_buffers:
+                if tool_call:
+                    function = {
+                        "name": tool_call.function_name,
+                        "arguments": "".join(tool_call.arguments),
+                    }
+                    tool_call_dict = {
+                        "id": tool_call.tool_call_id,
+                        "type": "function",
+                        "function": function,
+                    }
+                    tool_calls.append(tool_call_dict)
+            message["tool_calls"] = tool_calls
+
+        event_attributes = {
+            gen_ai_attributes.GEN_AI_SYSTEM: gen_ai_attributes.GenAiSystemValues.ANTHROPIC.value,
+            "index": index,
+            "finish_reason": choice.finish_reason or "none",
+            "message": json.dumps(message),
+        }
+        span.add_event("gen_ai.choice", attributes=event_attributes)
+
+
+class SystemMessageParam(TypedDict):
+    role: Literal["system"]
+    content: str | Iterable[TextBlockParam]
+
+
+def set_message_event(span: Span, message: MessageParam | SystemMessageParam) -> None:
+    """Add a message event to the span with appropriate attributes."""
+    attributes: dict[str, AttributeValue] = {
+        gen_ai_attributes.GEN_AI_SYSTEM: gen_ai_attributes.GenAiSystemValues.ANTHROPIC.value
+    }
+
+    role = message["role"]
+
+    if content := message.get("content"):
+        if isinstance(content, str):
+            attributes["content"] = content
+        elif isinstance(content, list):
+            text_parts = []
+            tool_calls: list[LLMOpenTelemetryToolCall] = []
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "text":
+                        text_parts.append(block.get("text", ""))
+                    elif block.get("type") == "tool_use":
+                        tool_calls.append(
+                            {
+                                "id": block.get("id", ""),
+                                "type": "function",
+                                "function": {
+                                    "name": block.get("name", ""),
+                                    "arguments": json_dumps(block.get("input", {})),
+                                },
+                            }
+                        )
+
+            if text_parts:
+                attributes["content"] = "\n".join(text_parts)
+            if tool_calls:
+                attributes["tool_calls"] = json_dumps(tool_calls)
+        else:
+            attributes["content"] = json_dumps(content)
+
+    span.add_event(
+        f"gen_ai.{role}.message",
+        attributes=attributes,
+    )
+
+
+def get_choice_event(
+    content_block: ContentBlock, role: Literal["assistant"], stop_reason: str | None
+) -> dict[str, AttributeValue]:
+    """Returns event attributes extracted from a content block."""
+    attributes: dict[str, AttributeValue] = {
+        gen_ai_attributes.GEN_AI_SYSTEM: gen_ai_attributes.GenAiSystemValues.ANTHROPIC.value
+    }
+
+    message: LLMOpenTelemetryMessage = {"role": role}
+
+    if isinstance(content_block, TextBlock):
+        message["content"] = content_block.text
+    elif isinstance(content_block, ToolUseBlock):
+        message["tool_calls"] = [
+            {
+                "id": content_block.id,
+                "type": "function",
+                "function": {
+                    "name": content_block.name,
+                    "arguments": json_dumps(content_block.input)
+                    if content_block.input
+                    else "{}",
+                },
+            }
+        ]
+
+    attributes["message"] = json_dumps(message)
+    attributes["finish_reason"] = stop_reason or "error"
+    return attributes
+
+
+def set_response_attributes(span: Span, response: Message) -> None:
+    """Set span attributes from a Message response object."""
+    attributes: dict[str, AttributeValue] = {
+        gen_ai_attributes.GEN_AI_RESPONSE_MODEL: response.model
+    }
+
+    if content := response.content:
+        for index, content_block in enumerate(content):
+            choice_attributes = get_choice_event(
+                content_block, response.role, response.stop_reason
+            )
+            choice_attributes["index"] = index
+            span.add_event(
+                "gen_ai.choice",
+                attributes=choice_attributes,
+            )
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_FINISH_REASONS] = [
+            response.stop_reason or "error"
+        ]
+
+    if response.id:
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_ID] = response.id
+
+    if usage := response.usage:
+        attributes[gen_ai_attributes.GEN_AI_USAGE_INPUT_TOKENS] = usage.input_tokens
+        attributes[gen_ai_attributes.GEN_AI_USAGE_OUTPUT_TOKENS] = usage.output_tokens
+
+    span.set_attributes(attributes)
+
+
+def get_llm_request_attributes(
+    kwargs: dict[str, Any],
+    client_instance: Any,
+    operation_name: str = gen_ai_attributes.GenAiOperationNameValues.CHAT.value,
+) -> dict[str, AttributeValue]:
+    """Extract OpenTelemetry attributes from Anthropic API request parameters."""
+    attributes: dict[str, AttributeValue] = {
+        gen_ai_attributes.GEN_AI_OPERATION_NAME: operation_name,
+        gen_ai_attributes.GEN_AI_SYSTEM: gen_ai_attributes.GenAiSystemValues.ANTHROPIC.value,
+    }
+
+    if model := kwargs.get("model"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_MODEL] = model
+    if temperature := kwargs.get("temperature"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_TEMPERATURE] = temperature
+    if top_p := kwargs.get("top_p"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_TOP_P] = top_p
+    if top_k := kwargs.get("top_k"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_TOP_K] = top_k
+    if max_tokens := kwargs.get("max_tokens"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_MAX_TOKENS] = max_tokens
+    if stop_sequences := kwargs.get("stop_sequences"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_STOP_SEQUENCES] = stop_sequences
+
+    set_server_address_and_port(client_instance, attributes)
+    return {k: v for k, v in attributes.items() if v is not None}

--- a/sdks/python/src/lilypad/_internal/otel/anthropic/instrument.py
+++ b/sdks/python/src/lilypad/_internal/otel/anthropic/instrument.py
@@ -1,0 +1,66 @@
+"""Anthropic client instrumentation for OpenTelemetry tracing.
+
+This module provides instrumentation for the Anthropic Python client to automatically
+create OpenTelemetry spans for API calls.
+"""
+
+import logging
+from importlib.metadata import PackageNotFoundError, version
+
+from wrapt import FunctionWrapper
+from anthropic import Anthropic, AsyncAnthropic
+from opentelemetry.trace import get_tracer
+from opentelemetry.semconv.schemas import Schemas
+
+from . import _patch
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: see if we can refactor this with other providers in a way that makes sense
+def instrument_anthropic(client: Anthropic | AsyncAnthropic) -> None:
+    """
+    Instrument the Anthropic client with OpenTelemetry tracing.
+
+    Args:
+        client: The Anthropic client instance to instrument.
+    """
+    if hasattr(client, "_lilypad_instrumented"):
+        logger.debug(f"{type(client).__name__} already instrumented, skipping")
+        return
+
+    try:
+        lilypad_version = version("lilypad-sdk")
+    except PackageNotFoundError:
+        lilypad_version = "unknown"
+        logger.debug("Could not determine lilypad-sdk version")
+
+    tracer = get_tracer(
+        __name__,
+        lilypad_version,
+        schema_url=Schemas.V1_28_0.value,
+    )
+
+    if isinstance(client, AsyncAnthropic):
+        try:
+            client.messages.create = FunctionWrapper(
+                client.messages.create,
+                _patch.messages_create_async_patch_factory(tracer),
+            )
+            logger.debug("Successfully wrapped AsyncMessages.create")
+        except Exception as e:
+            logger.warning(
+                f"Failed to wrap AsyncMessages.create: {type(e).__name__}: {e}"
+            )
+
+    else:
+        try:
+            client.messages.create = FunctionWrapper(
+                client.messages.create,
+                _patch.messages_create_patch_factory(tracer),
+            )
+            logger.debug("Successfully wrapped Messages.create")
+        except Exception as e:
+            logger.warning(f"Failed to wrap Messages.create: {type(e).__name__}: {e}")
+
+    client._lilypad_instrumented = True  # pyright: ignore[reportAttributeAccessIssue]

--- a/sdks/python/src/lilypad/_internal/otel/openai/_utils.py
+++ b/sdks/python/src/lilypad/_internal/otel/openai/_utils.py
@@ -34,6 +34,7 @@ from opentelemetry.util.types import AttributeValue
 from openai.types.chat.chat_completion import Choice
 from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
 
+from ..types import LLMOpenTelemetryMessage
 from ..utils import BaseMetadata, ChoiceBuffer, ChunkHandler
 from ...utils import json_dumps
 
@@ -104,7 +105,7 @@ def default_openai_cleanup(
         attributes[gen_ai_attributes.GEN_AI_RESPONSE_FINISH_REASONS] = finish_reasons
 
     span.set_attributes(attributes)
-    for idx, choice in enumerate(buffers):
+    for index, choice in enumerate(buffers):
         message: dict[str, str | dict[str, str] | list[str]] = {"role": "assistant"}
         if choice.text_content:
             message["content"] = "".join(choice.text_content)
@@ -126,7 +127,7 @@ def default_openai_cleanup(
 
         event_attributes: dict[str, AttributeValue] = {
             gen_ai_attributes.GEN_AI_SYSTEM: "openai",
-            "index": idx,
+            "index": index,
             "finish_reason": choice.finish_reason or "none",
             "message": json.dumps(message),
         }
@@ -206,7 +207,7 @@ def get_choice_event(choice: Choice) -> dict[str, AttributeValue]:
     }
 
     if message := choice.message:
-        message_dict: ChatCompletionMessageParam = {
+        message_dict: LLMOpenTelemetryMessage = {
             "role": message.role,
         }
         if content := message.content:

--- a/sdks/python/src/lilypad/_internal/otel/openai/instrument.py
+++ b/sdks/python/src/lilypad/_internal/otel/openai/instrument.py
@@ -33,6 +33,7 @@ from . import _patch
 logger = logging.getLogger(__name__)
 
 
+# TODO: see if we can refactor this with other providers in a way that makes sense
 def instrument_openai(client: OpenAI | AsyncOpenAI) -> None:
     """
     Instrument the OpenAI client with OpenTelemetry tracing.

--- a/sdks/python/src/lilypad/_internal/otel/types.py
+++ b/sdks/python/src/lilypad/_internal/otel/types.py
@@ -1,0 +1,38 @@
+"""Types for OpenTelemetry provider-agnostic LLM handling."""
+
+from typing import Literal
+from typing_extensions import Required, TypedDict
+
+
+class LLMOpenTelemetryFunctionCall(TypedDict):
+    arguments: str
+    """The arguments of the function call as a JSON string."""
+
+    name: str
+    """The name of the function to call."""
+
+
+class LLMOpenTelemetryToolCall(TypedDict):
+    """A provider-agnostic type for tool call parameters."""
+
+    id: str
+    """The ID of the tool call."""
+
+    type: Literal["function"]
+    """The discriminated union type "tool_call" for this type."""
+
+    function: LLMOpenTelemetryFunctionCall
+    """The function call"""
+
+
+class LLMOpenTelemetryMessage(TypedDict, total=False):
+    """A provider-agnostic type for message parameters."""
+
+    role: Required[str]
+    """The role of the message."""
+
+    content: str
+    """The content of the message."""
+
+    tool_calls: list[LLMOpenTelemetryToolCall]
+    """The list of tool calls, if any."""

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -16,6 +16,24 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.63.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/6e/3bedbd1c932cce98495e007b6d8007a139cf46adc5c889d700ec75ddd7f3/anthropic-0.63.0.tar.gz", hash = "sha256:d75ecfff17a0b96d845be3cbd93e06a48ea95aaa27add586748772fa5b926994", size = 427391, upload-time = "2025-08-12T16:59:58.079Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/a1/83bdb1a8be76fbb3ceedae9dfe1b515cff56dcfbbc388b53070a27ce341f/anthropic-0.63.0-py3-none-any.whl", hash = "sha256:d1849fe1635ae4277f45a0e4365979ed69e6264b73350ce8a99fee701d347745", size = 296637, upload-time = "2025-08-12T16:59:56.841Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -392,6 +410,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+anthropic = [
+    { name = "anthropic" },
+]
 openai = [
     { name = "openai" },
 ]
@@ -403,6 +424,7 @@ dev = [
     { name = "ruff" },
 ]
 examples = [
+    { name = "anthropic" },
     { name = "openai" },
 ]
 test = [
@@ -417,6 +439,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.63.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.98.0" },
     { name = "opentelemetry-api", specifier = ">=1.36.0" },
@@ -426,7 +449,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "wrapt", specifier = ">=1.17.2" },
 ]
-provides-extras = ["openai"]
+provides-extras = ["openai", "anthropic"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -434,7 +457,10 @@ dev = [
     { name = "pyright", specifier = ">=1.1.403" },
     { name = "ruff", specifier = ">=0.12.7" },
 ]
-examples = [{ name = "openai", specifier = ">=1.98.0" }]
+examples = [
+    { name = "anthropic", specifier = ">=0.63.0" },
+    { name = "openai", specifier = ">=1.98.0" },
+]
 test = [
     { name = "inline-snapshot", specifier = ">=0.23.0" },
     { name = "pytest", specifier = ">=8.0.0" },


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry instrumentation for Anthropic's Python client to enable tracing of API calls.

### What changed?

- Implemented a new module for instrumenting Anthropic's Python client with OpenTelemetry
- Added support for both synchronous and asynchronous clients
- Created utility functions to extract and format telemetry data from Anthropic API responses
- Added support for streaming and non-streaming responses
- Implemented proper handling of tool calls and content blocks
- Added an example script demonstrating how to use the instrumentation with a console exporter

### How to test?

Run the new example script to see the instrumentation in action:

```bash
python sdks/python/examples/instrument_anthropic_with_console.py
```

This will make a simple request to Claude and output the trace information to the console, showing the captured spans and events.

### Why make this change?

This change extends Lilypad's observability capabilities to include Anthropic's Claude models, allowing users to trace and monitor their Anthropic API calls alongside other LLM providers. The instrumentation captures important metrics like token usage, model information, and response details, enabling better debugging, monitoring, and analysis of AI applications that use Anthropic's models.