### PR TITLE
Add Unit Tests for Anthropic OpenTelemetry Instrumentation

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = node_modules,bun.lock,dist,coverage
+skip = node_modules,bun.lock,dist,coverage,**/cassettes/**,htmlcov
 ignore-words-list = afterAll,assistin

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:python-sdk:coverage": "cd sdks/python && uv run pytest --cov --cov-config=.coveragerc --cov-report=term-missing",
     "test:python-sdk:watch": "cd sdks/python && uv run pytest-watch",
     "test:ci": "bun run test:coverage && bun run test:python-sdk",
-    "codespell": "uvx codespell --skip node_modules,bun.lock",
+    "codespell": "uvx codespell --skip node_modules,bun.lock,dist,coverage,**/cassettes/**,htmlcov",
     "typecheck": "bun x tsc --build ./tsconfig.json",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/sdks/python/tests/conftest.py
+++ b/sdks/python/tests/conftest.py
@@ -75,9 +75,14 @@ def _filter_response_headers(response: Response) -> Response:
     sensitive_headers = {
         "openai-organization",
         "openai-project",
+        "anthropic-organization-id",
         "cf-ray",
         "x-request-id",
+        "request-id",
         "set-cookie",
+        "x-stainless-arch",
+        "x-stainless-os",
+        "x-stainless-runtime-version",
     }
 
     filtered_headers = {
@@ -114,7 +119,11 @@ def vcr_config() -> VCRConfig:
             "openai-project",
             "cf-ray",
             "x-request-id",
+            "request-id",
             "set-cookie",
+            "x-stainless-arch",
+            "x-stainless-os",
+            "x-stainless-runtime-version",
         ],
         "filter_post_data_parameters": [],
         "before_record_response": _filter_response_headers,

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_assistant_message_with_empty_content.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_assistant_message_with_empty_content.yaml
@@ -1,0 +1,93 @@
+interactions:
+- request:
+    body: '{"max_tokens":50,"messages":[{"role":"user","content":"What''s 5+5?"},{"role":"assistant","content":[{"type":"tool_use","id":"tool_123","name":"calculator","input":{"operation":"add","a":5,"b":5}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool_123","content":"10"}]}],"model":"claude-3-haiku-20240307"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '324'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2SQzWrDMBCEX0XMtXKxnYa2eoYcmlLooRQhpE2sxpFS7ap/Ju9eHJpD6Glhvplh
+        mQkxwGDPW9t2D+nzsbvv3Y433fN+tXpbp3X/Aw35PtDsIma3JWiUPM6CY44sLgk09jnQCAM/uhqo
+        WTSDi7va9G1/0y7aW2j4nISSwLxM50ahrzl7OgZPA6lCXEdReaOW6kotVWTVtdc4vmqw5IMt5Dgn
+        GFAKVmpJ+ANM75WSJ5hUx1Gjnl41E2I6VLGSd5QYput6De/8QNYXchJzspeO9swLufCf5SoXfXca
+        TOUjerISqcBgXiS4EnA8/gIAAP//AwAI5/m+XwEAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 09:08:21 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T09:08:20Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T09:08:20Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T09:08:20Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T09:08:20Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_async_message_creation_simple.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_async_message_creation_simple.yaml
@@ -1,0 +1,94 @@
+interactions:
+- request:
+    body: '{"max_tokens":50,"messages":[{"role":"user","content":"Hello, say ''Hi''
+      back to me"}],"model":"claude-3-haiku-20240307"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '119'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.63.0
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//ZI9BS8QwFIR/i3NOod1uLeQs4sGDrHgSCSF57MZtX7rJi66U/nfp4oLi
+        6cF8M8ObGcFDY8x7Uzfd/ak9P33e7saXvnl8fue2G+kOCvI10eqinO2eoJDisAo255DFskBhjJ4G
+        aLjBFk9VWx1sOJZqU2+2dVv3UHCRhVigX+dro9B5zV6OxkO4wfKmkCVOJpHNkaFB7I2UxPgBmU6F
+        2BE0l2FQKJef9IzAUxEj8UicoZtewVl3IOMSWQmRzV9DfeWJrP/PYpHfSqeQKX0ER0YCJWisw71N
+        HsvyDQAA//8DAKaWJoRGAQAA
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 08:55:15 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T08:55:15Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T08:55:15Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T08:55:15Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T08:55:15Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_async_streaming_message_creation.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_async_streaming_message_creation.yaml
@@ -1,0 +1,135 @@
+interactions:
+- request:
+    body: '{"max_tokens":50,"messages":[{"role":"user","content":"Count to 3"}],"model":"claude-3-haiku-20240307","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '117'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.63.0
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_012S7swkBWUBeEygZoEYh18Z","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":3,"service_tier":"standard"}}         }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}            }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"1,"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        2, "}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"3."}
+        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0          }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":12}   }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"   }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 13 Aug 2025 08:55:18 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T08:55:18Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T08:55:18Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T08:55:18Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T08:55:18Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_async_streaming_multiple_content_blocks.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_async_streaming_multiple_content_blocks.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: '{"max_tokens":200,"messages":[{"role":"user","content":"First say hello,
+      then use the weather tool to check Tokyo weather"}],"model":"claude-3-haiku-20240307","stream":true,"tools":[{"name":"get_weather","description":"Get
+      weather for a location","input_schema":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '350'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.63.0
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_015JAWfP45jQQdTTZrdjm26V","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":337,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"service_tier":"standard"}}}
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01Qrtq4c3NtdEVGwuANq2z1J","name":"get_weather","input":{}}               }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"l"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"oca"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tion\":
+        \"Tok"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"yo"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"}"}               }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0       }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":53}
+        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop" }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 13 Aug 2025 12:26:50 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T12:26:50Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T12:26:50Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T12:26:50Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T12:26:50Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_async_streaming_with_multiple_blocks.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_async_streaming_with_multiple_blocks.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: '{"max_tokens":200,"messages":[{"role":"user","content":"First say hello,
+      then use a tool to get weather"}],"model":"claude-3-haiku-20240307","stream":true,"tools":[{"name":"get_weather","description":"Get
+      weather for a location","input_schema":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '332'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.63.0
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_017g5nGzRt4EZ99PJCL3mPcV","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":335,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"service_tier":"standard"}}              }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_012Ve9LFLZeA5nuaqr4CXMrU","name":"get_weather","input":{}}              }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"locat"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ion\":
+        \"New"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        Yor"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"k,
+        "}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"NY\"}"}
+        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0          }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":56}               }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"    }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 13 Aug 2025 09:08:20 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T09:08:19Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T09:08:19Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T09:08:19Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T09:08:19Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_error_handling.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_error_handling.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: '{"max_tokens":50,"messages":[{"role":"user","content":"Hello"}],"model":"invalid-model-name"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '93'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6pWKqksSFWyUkotKsovUtKB0lbVMPG8/JL4tPzSvJR4mIrc1OLixHSQXG5+SmqO
+        lUJmXlliTmaKLpirm5eYm6pUWwsAAAD//wMAjVHFuVkAAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 08:55:20 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+      x-should-retry:
+      - 'false'
+    status:
+      code: 404
+      message: Not Found
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_message_with_advanced_params.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_message_with_advanced_params.yaml
@@ -1,0 +1,94 @@
+interactions:
+- request:
+    body: '{"max_tokens":50,"messages":[{"role":"user","content":"Count from 1 to
+      10"}],"model":"claude-3-haiku-20240307","stop_sequences":["5","STOP"],"temperature":0.5,"top_k":40,"top_p":0.9}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '182'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//ZI7NasMwEIRfxcxZBjt2KNWt0F5DeymEUoSQFkfYkVytFByM373YJQfT
+        0zI7P3wznIXElTtV1a+n7vPefUyn8+1N80sYn8/Tew+BdB9pTRGz7ggCMQzrQzM7TtonCFyDpQES
+        ZtDZUtmUF+36XB6qQ1s11RMETPCJfIL8mh+Liaa1ux2JWhQHUTSiaEWB5VuAUxhVJM3BQ/4ppp9M
+        3qwQey1xhEDeAOUM58ecVAo9eYasjwJGmwspE0knF7zaB6qHH0nb/17IaTfXCjDFmzOkkqO4wWlv
+        dbRYll8AAAD//wMAf0AiP1QBAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 09:08:18 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T09:08:18Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T09:08:18Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T09:08:18Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T09:08:18Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_multiple_content_blocks_in_response.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_multiple_content_blocks_in_response.yaml
@@ -1,0 +1,96 @@
+interactions:
+- request:
+    body: '{"max_tokens":200,"messages":[{"role":"user","content":"Use the calculator
+      to add 2+2, then explain the result"}],"model":"claude-3-haiku-20240307","tools":[{"name":"calculator","description":"A
+      simple calculator","input_schema":{"type":"object","properties":{"operation":{"type":"string","enum":["add","subtract"]},"a":{"type":"number"},"b":{"type":"number"}},"required":["operation","a","b"]}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '397'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//ZFBdSwMxEPwv85zC9c5qmzcfrKA+FLFKFQkxWdrYXHLNx1E5+t8lJwXF
+        l4Wdmd2Z3QFGg6ONW1FN759r83Bol7eLY02rWbfefK58D4b01VFRUYxyS2AI3hZAxmhiki6BofWa
+        LDiUlVnTpJnspNnnSV3VF1VTXYFBeZfIJfC34bwxeW9FjmXlmKP0WVTTzVI3Rzd9Wc+f+v5R3rze
+        +fp6AQYn2zKnpFXZyuRDmXRdTuADJHjN8DFW31GQyXhXYmqN0+mdISbfiUAyjvAv85GIdMjkFIG7
+        bC1DHo/lw4+BSH5PLoI3lwsGJdWOhAo0eoi/iurMB5L6P+dz+o3MZwyRQm8UiWQogKP8VMtQUn8D
+        AAD//wMAMsLxoaEBAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 09:08:19 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T09:08:18Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T09:08:19Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T09:08:18Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T09:08:18Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_streaming_max_tokens_stop_reason.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_streaming_max_tokens_stop_reason.yaml
@@ -1,0 +1,141 @@
+interactions:
+- request:
+    body: '{"max_tokens":10,"messages":[{"role":"user","content":"Write a very long
+      story about a robot"}],"model":"claude-3-haiku-20240307","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '144'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_018dfAvKYnjmrx6J8ppbmj5u","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"service_tier":"standard"}}        }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}      }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        is a very long"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        story about a robot"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":"}}
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0             }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"output_tokens":10}        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"   }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 13 Aug 2025 12:27:51 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T12:27:51Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T12:27:51Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T12:27:51Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T12:27:51Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_streaming_stop_sequence_triggered.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_streaming_stop_sequence_triggered.yaml
@@ -1,0 +1,142 @@
+interactions:
+- request:
+    body: '{"max_tokens":100,"messages":[{"role":"user","content":"Count from 1 to
+      10"}],"model":"claude-3-haiku-20240307","stop_sequences":["5"],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '149'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_0179majyGE6kLG6cM5jSZAdx","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":3,"service_tier":"standard"}}           }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}            }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"1,"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        2, "}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"3,
+        4"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
+        "}        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0            }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"5"},"usage":{"output_tokens":14}           }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"          }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 13 Aug 2025 12:27:58 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T12:27:58Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T12:27:58Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T12:27:58Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T12:27:58Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_streaming_with_input_json_delta.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_streaming_with_input_json_delta.yaml
@@ -1,0 +1,198 @@
+interactions:
+- request:
+    body: '{"max_tokens":300,"messages":[{"role":"user","content":"Use the calculator
+      to compute 42 * 17"}],"model":"claude-3-5-sonnet-20241022","stream":true,"tools":[{"name":"calculator","description":"Performs
+      calculations","input_schema":{"type":"object","properties":{"expression":{"type":"string"}},"required":["expression"]}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '323'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01MVpyWMCxqqTBM4o9uyYJ49","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":380,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}  }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}               }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''ll"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        help"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        you calculate"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        42 multipl"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ied
+        by 17 "}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"using
+        the calculator tool"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}           }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0             }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_016GFtMEs6NRjMteg9c9fE4v","name":"calculator","input":{}}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"expres"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"sion\":
+        \"42"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"
+        * 17\"}"}        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1        }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":75}            }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"          }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 13 Aug 2025 23:33:38 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T23:33:38Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T23:33:38Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T23:33:38Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T23:33:38Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_structured_user_content_as_text.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_structured_user_content_as_text.yaml
@@ -1,0 +1,93 @@
+interactions:
+- request:
+    body: '{"max_tokens":5,"messages":[{"role":"user","content":"Simple text message"}],"model":"claude-3-haiku-20240307"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '111'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2SQTUvEMBCG/4q8Fy8pdD9kIWcviqgHiywiJSaz29g2qZmJ7FL636WLK4qngfd5
+        5oMZ4R00et7X5aK6q6r1LT895mZ7Xb1tn4fN/e4dCnIcaLaI2ewJCil2c2CYPYsJAoU+OuqgYTuT
+        HRWrojG+zcWyXK7LVbmBgo1BKAj0y3ieKHSYe09F46E1R3Vxc9ljelVgiUOdyHAM825zqCW2FBjf
+        iOkjU7AEHXLXKeTTbXqED0OWs6wXpYI1tqHaJjLiY6j/Cj88kXH/WczyO7lSYEqf3lItnhI05gc4
+        kxym6QsAAP//AwA1EVjaTgEAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 09:11:55 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T09:11:55Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T09:11:55Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T09:11:55Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T09:11:55Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_message_creation_simple.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_message_creation_simple.yaml
@@ -1,0 +1,94 @@
+interactions:
+- request:
+    body: '{"max_tokens":50,"messages":[{"role":"user","content":"Hello, say ''Hi''
+      back to me"}],"model":"claude-3-haiku-20240307"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '119'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//ZI/NasMwEISfpXOWwfkjoFsJOIGAoadASxFCWmIRZ+VKq9Jg/O7FoYGW
+        nhbmmxl2RgQPjWs+m3qxj+161+xv6Xh4aXbNczq13WsLBbkNNLsoZ3smKKTYz4LNOWSxLFC4Rk89
+        NFxvi6dqVXU2XEq1rJfrelVvoeAiC7FAv42PRqGvOXs/GofwhOldIUscTCKbI0OD2BspifEDMn0U
+        YkfQXPpeodx/0iMCD0WMxAtxhl5sFZx1HRmXyEqIbP4a6gdPZP1/Fov8VjYKmdJncGQkUILGPNzb
+        5DFN3wAAAP//AwBDO2eaRgEAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 08:55:06 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T08:55:06Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T08:55:06Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T08:55:05Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T08:55:06Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_message_creation_with_system.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_message_creation_with_system.yaml
@@ -1,0 +1,96 @@
+interactions:
+- request:
+    body: '{"max_tokens":100,"messages":[{"role":"user","content":"What is the capital
+      of France?"}],"model":"claude-3-haiku-20240307","system":"You are a helpful
+      assistant who speaks like a pirate.","temperature":0.7}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '207'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//ZJBBSwMxFIT/SpyLl1S2rVjIrQf1oIJCEVRkeU0e3dhtsk1eStfS/y5b
+        9KCeHsw3M/DmAO9gsMmruhpffy78B79uV7uH2/l+Obu7fx6/PEFD+o4HF+dMK4ZGiu0gUM4+CwWB
+        xiY6bmFgWyqOR9NRQ35dRpNqcllNqxk0bAzCQWDeDj+NwvshezoG8yb2Wm1YNUxJ+jO1aFhZ6rxQ
+        q+K5ukkULKslK2lYZVvSrlfWSz/AR0o+X+D4rpEldnViyjHAgIOrpaSAb5B5WzhYhgmlbTXK6Sdz
+        gA9dkVrimkOGmVxpWLIN1zYxiY+h/m2ofnhicv9ZLPK3LnPaecu1eE4wGJZzlByOxy8AAAD//wMA
+        F8hh9IcBAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 08:55:16 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T08:55:16Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T08:55:16Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T08:55:16Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T08:55:16Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_message_creation_with_tools.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_message_creation_with_tools.yaml
@@ -1,0 +1,99 @@
+interactions:
+- request:
+    body: "{\"max_tokens\":200,\"messages\":[{\"role\":\"user\",\"content\":\"What's
+      the weather in Tokyo today?\"}],\"model\":\"claude-3-haiku-20240307\",\"tools\":[{\"name\":\"get_weather\",\"description\":\"Get
+      today's weather report\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"City
+      and country e.g. Bogot\xE1, Colombia\"},\"units\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"],\"description\":\"Units
+      the temperature will be returned in.\"}},\"required\":[\"location\",\"units\"]}}]}"
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '486'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//ZFFdaxsxEPwrx7zkRYZz3GJXbwltKCVQaA1JCEGo0nKnnizZ0srJxdx/
+        L7omJKVPy+7szOzHCc5CYpc71S4vt9vfj1dfLnd36x/XXXd1XB5+DhcQ4HFPtYty1h1BIEVfCzpn
+        l1kHhsAuWvKQMF4XS4vVotduKIvz9vxDu2rXEDAxMAWGvD+9KjI9Ve4cJL4PehSNJz7LjenJDA33
+        1DyS5p5S40KzjcMYG45WjxKTeJOJ0auS62TzOjUvql3e2NvPz+ukx5uDPX6Nd78Ox03/DIGgd5XX
+        EasX+UoN+8KQJ/hoNLsYIDE7iuab3usAgRIc57ok+exKxjQ9CGSOe5VI55nxbpYZyHQoFAxBhuK9
+        QJlPKE9/7RTHgUKGXG0+CRhtelIm0Wyv/u1oX/FE2v6PxcLvK5uPApnS0RlS7ChBon7K6mQxTX8A
+        AAD//wMAVRxTavcBAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 08:55:17 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T08:55:16Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T08:55:17Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T08:55:16Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T08:55:16Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_streaming_message_creation.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_streaming_message_creation.yaml
@@ -1,0 +1,135 @@
+interactions:
+- request:
+    body: '{"max_tokens":50,"messages":[{"role":"user","content":"Count to 3"}],"model":"claude-3-haiku-20240307","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '117'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01QorJUmt7CFdfYTNL225E1s","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":3,"service_tier":"standard"}}       }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"1,"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        2, "}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"3."}     }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0     }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":12}          }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"   }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 13 Aug 2025 08:55:17 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T08:55:17Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T08:55:17Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T08:55:17Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T08:55:17Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_streaming_message_creation_with_tools.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_streaming_message_creation_with_tools.yaml
@@ -1,0 +1,215 @@
+interactions:
+- request:
+    body: "{\"max_tokens\":200,\"messages\":[{\"role\":\"user\",\"content\":\"What's
+      the weather in Tokyo today?\"}],\"model\":\"claude-3-haiku-20240307\",\"stream\":true,\"tools\":[{\"name\":\"get_weather\",\"description\":\"Get
+      today's weather report\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"location\":{\"type\":\"string\",\"description\":\"City
+      and country e.g. Bogot\xE1, Colombia\"},\"units\":{\"type\":\"string\",\"enum\":[\"celsius\",\"fahrenheit\"],\"description\":\"Units
+      the temperature will be returned in.\"}},\"required\":[\"location\",\"units\"]}}]}"
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '500'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01UWHNFBLJLDBkSePZiWAuWW","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":389,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":2,"service_tier":"standard"}}
+        }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}       }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Okay"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
+        let me check"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the weather for you"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        in"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Tokyo today"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":"}    }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0 }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01DL5y2R7EpDetYdavzqrn9s","name":"get_weather","input":{}}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":":
+        \"Toky"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"o,
+        Ja"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"pan"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":",
+        \"units\": "}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"celsius"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"}"}   }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1            }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":87}               }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"      }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 13 Aug 2025 08:55:18 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T08:55:18Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T08:55:18Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T08:55:18Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T08:55:18Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_streaming_tool_use_detailed.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_streaming_tool_use_detailed.yaml
@@ -1,0 +1,215 @@
+interactions:
+- request:
+    body: '{"max_tokens":200,"messages":[{"role":"user","content":"Calculate 123 *
+      456 using the calculator tool"}],"model":"claude-3-5-sonnet-20241022","stream":true,"tools":[{"name":"calculator","description":"Performs
+      basic arithmetic","input_schema":{"type":"object","properties":{"operation":{"type":"string","enum":["multiply","add","subtract","divide"]},"a":{"type":"number"},"b":{"type":"number"}},"required":["operation","a","b"]}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '431'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01EP6EGGKpKQNgBtecdZ2RxB","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":423,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"service_tier":"standard"}}   }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''ll
+        help"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        you multiply 123 by "}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"456
+        using the calculator"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        tool."}         }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0              }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01HfCf8ib3nRGcpqyyQ46gqF","name":"calculator","input":{}}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"o"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"per"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"ation\":
+        \"m"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"ultipl"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"y\""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":",
+        \""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"a\":
+        123"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":",
+        \"b"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\":
+        456}"}  }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1 }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":103}               }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"              }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 13 Aug 2025 11:53:03 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T11:53:02Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T11:53:02Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T11:53:02Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T11:53:02Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_streaming_with_stop_sequence.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_sync_streaming_with_stop_sequence.yaml
@@ -1,0 +1,142 @@
+interactions:
+- request:
+    body: '{"max_tokens":100,"messages":[{"role":"user","content":"Count from 1 to
+      10"}],"model":"claude-3-haiku-20240307","stop_sequences":["5"],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '149'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01MkwFJN43cbW1dV6aLXEoH9","type":"message","role":"assistant","model":"claude-3-haiku-20240307","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":3,"service_tier":"standard"}}   }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"1,"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        2, "}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"3,
+        4"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
+        "}              }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0}
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"5"},"usage":{"output_tokens":14}               }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"        }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 13 Aug 2025 09:08:21 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T09:08:21Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T09:08:21Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T09:08:21Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T09:08:21Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_tool_message_with_tool_use_id.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_tool_message_with_tool_use_id.yaml
@@ -1,0 +1,93 @@
+interactions:
+- request:
+    body: '{"max_tokens":100,"messages":[{"role":"user","content":"What''s 2+2?"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_test123","name":"calculate","input":{"expression":"2+2"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_test123","content":"4"}]}],"model":"claude-3-haiku-20240307"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '322'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2SQUUsDMRCE/0qYV3NyvRZa8iYI+lJBKFgRCSHZtqHX5MxuRC3973JFRfFpYb6Z
+        YZkjYoDBgbe2nSwfF+uHtLy+Wd3W7ZrnH3dpcn8FDXkfaHQRs9sSNEruR8ExRxaXBBqHHKiHge9d
+        DdRMm52L+9p0bTdrp+0cGj4noSQwT8fvRqG3MXs+BqsdqUJce1F5ozp1oToVWc0ucXrWYMmDLeQ4
+        JxhQClZqSfgCTC+VkieYVPteo54/NUfENFSxkveUGGbRanjnd2R9IScxJ/vX8MMLufCf5Sq/lclC
+        g6m8Rk9WIhUYjHsEVwJOp08AAAD//wMAUd9KU10BAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 08:55:20 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T08:55:19Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T08:55:19Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T08:55:19Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T08:55:19Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_user_structured_content_is_jsonified.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/cassettes/test_user_structured_content_is_jsonified.yaml
@@ -1,0 +1,94 @@
+interactions:
+- request:
+    body: '{"max_tokens":5,"messages":[{"role":"user","content":[{"type":"text","text":"Reply
+      with OK"}]}],"model":"claude-3-haiku-20240307"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '130'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA2SPzUoEMRCE36XOGZjdHRRyFUFWxIt6EQkhaWfDznbGdGf9GebdZRYVxVNDfVVF
+        14QUYXGQ3rWrq+P93UfdlrG+dunmbHv58HxRehjo+0iLi0R8TzAoeVgEL5JEPSsMDjnSAIsw+Bqp
+        2TQ7n/a1Wbfrrt205zAImZVYYR+n70altyV7Oha315ifDETz6Ap5yQwL4ui0FsYXEHqpxIFguQ6D
+        QT29ZCckHqs6zXtigV21BsGHHblQyGvK7P4afnghH/+zXPW30hkIlWMK5DRRgcWyO/oSMc+fAAAA
+        //8DAH4Wt45FAQAA
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 13 Aug 2025 08:55:20 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-13T08:55:20Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-13T08:55:20Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-13T08:55:20Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-13T08:55:20Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/anthropic/test_instrument.py
+++ b/sdks/python/tests/lilypad/_internal/otel/anthropic/test_instrument.py
@@ -1,0 +1,1707 @@
+"""Tests for Anthropic instrumentation."""
+
+import os
+import inspect
+from unittest.mock import Mock, patch
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+from wrapt import FunctionWrapper
+from dotenv import load_dotenv
+from anthropic import (
+    Anthropic,
+    NotFoundError,
+    APIStatusError,
+    AsyncAnthropic,
+    RateLimitError,
+    APIConnectionError,
+)
+from anthropic.types import Message
+from inline_snapshot import snapshot
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from lilypad._internal.otel.anthropic.instrument import instrument_anthropic
+
+from ..test_utils import (
+    extract_span_data,
+)
+
+
+@pytest.fixture
+def anthropic_api_key() -> str:
+    """Get Anthropic API key from environment or return dummy key."""
+    load_dotenv()
+    return os.getenv("ANTHROPIC_API_KEY", "test-api-key")
+
+
+@pytest.fixture
+def client(anthropic_api_key: str) -> Anthropic:
+    """Create an instrumented Anthropic client."""
+    client = Anthropic(api_key=anthropic_api_key)
+    instrument_anthropic(client)
+    return client
+
+
+@pytest.fixture
+def async_client(anthropic_api_key: str) -> AsyncAnthropic:
+    """Create an instrumented AsyncAnthropic client."""
+    client = AsyncAnthropic(api_key=anthropic_api_key)
+    instrument_anthropic(client)
+    return client
+
+
+@pytest.mark.vcr()
+def test_sync_message_creation_simple(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test basic message creation with span verification."""
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Hello, say 'Hi' back to me"}],
+        max_tokens=50,
+    )
+
+    assert isinstance(response, Message)
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("end_turn",),
+                "gen_ai.response.id": "msg_01GoN4CFGyrKHQFCFArWNhZN",
+                "gen_ai.usage.input_tokens": 17,
+                "gen_ai.usage.output_tokens": 5,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Hello, say 'Hi' back to me",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","content":"Hi!"}',
+                        "index": 0,
+                        "finish_reason": "end_turn",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_async_message_creation_simple(
+    async_client: AsyncAnthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test async message creation with span verification."""
+    response = await async_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Hello, say 'Hi' back to me"}],
+        max_tokens=50,
+    )
+
+    assert isinstance(response, Message)
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("end_turn",),
+                "gen_ai.response.id": "msg_015Fq3xPw6RmU71LSjn35meD",
+                "gen_ai.usage.input_tokens": 17,
+                "gen_ai.usage.output_tokens": 5,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Hello, say 'Hi' back to me",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","content":"Hi!"}',
+                        "index": 0,
+                        "finish_reason": "end_turn",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_message_creation_with_system(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test message creation with system prompt and span verification."""
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",
+        system="You are a helpful assistant who speaks like a pirate.",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        temperature=0.7,
+        max_tokens=100,
+    )
+
+    assert isinstance(response, Message)
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.temperature": 0.7,
+                "gen_ai.request.max_tokens": 100,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("end_turn",),
+                "gen_ai.response.id": "msg_01EzTijeZqgvMGAxb7KLV1YQ",
+                "gen_ai.usage.input_tokens": 26,
+                "gen_ai.usage.output_tokens": 26,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.system.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "You are a helpful assistant who speaks like a pirate.",
+                    },
+                },
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "What is the capital of France?",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","content":"Ahoy, me hearty! The capital o\' France be the scurvy city o\' Paris."}',
+                        "finish_reason": "end_turn",
+                        "index": 0,
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_message_creation_with_tools(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test message creation with tools and span verification."""
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "What's the weather in Tokyo today?"}],
+        tools=[
+            {
+                "name": "get_weather",
+                "description": "Get today's weather report",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "City and country e.g. Bogotá, Colombia",
+                        },
+                        "units": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"],
+                            "description": "Units the temperature will be returned in.",
+                        },
+                    },
+                    "required": ["location", "units"],
+                },
+            }
+        ],
+        max_tokens=200,
+    )
+
+    assert isinstance(response, Message)
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 200,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("tool_use",),
+                "gen_ai.response.id": "msg_01BTTjwFEBmY7RLggFv1qSkA",
+                "gen_ai.usage.input_tokens": 389,
+                "gen_ai.usage.output_tokens": 85,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "What's the weather in Tokyo today?",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","content":"Okay, let\'s check the weather in Tokyo today:"}',
+                        "finish_reason": "tool_use",
+                        "index": 0,
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","tool_calls":[{"id":"toolu_01WdXDz7rayWqdvHoYbqv8hz","type":"function","function":{"name":"get_weather","arguments":"{\\"location\\":\\"Tokyo, Japan\\",\\"units\\":\\"celsius\\"}"}}]}',
+                        "finish_reason": "tool_use",
+                        "index": 1,
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_streaming_message_creation(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test streaming message creation with span verification."""
+    stream = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Count to 3"}],
+        max_tokens=50,
+        stream=True,
+    )
+
+    chunks = []
+    for chunk in stream:
+        chunks.append(chunk)
+
+    assert len(chunks) > 0
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.id": "msg_01QorJUmt7CFdfYTNL225E1s",
+                "gen_ai.response.finish_reasons": ("end_turn",),
+                "gen_ai.usage.input_tokens": 11,
+                "gen_ai.usage.output_tokens": 12,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Count to 3",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 0,
+                        "finish_reason": "end_turn",
+                        "message": '{"role": "assistant", "content": "1, 2, 3."}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_async_streaming_message_creation(
+    async_client: AsyncAnthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test async streaming with span verification."""
+    stream = await async_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Count to 3"}],
+        max_tokens=50,
+        stream=True,
+    )
+
+    chunks = []
+    async for chunk in stream:
+        chunks.append(chunk)
+
+    assert len(chunks) > 0
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.id": "msg_012S7swkBWUBeEygZoEYh18Z",
+                "gen_ai.response.finish_reasons": ("end_turn",),
+                "gen_ai.usage.input_tokens": 11,
+                "gen_ai.usage.output_tokens": 12,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Count to 3",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 0,
+                        "finish_reason": "end_turn",
+                        "message": '{"role": "assistant", "content": "1, 2, 3."}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_streaming_message_creation_with_tools(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test streaming message creation with tools and span verification."""
+    stream = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "What's the weather in Tokyo today?"}],
+        tools=[
+            {
+                "name": "get_weather",
+                "description": "Get today's weather report",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "City and country e.g. Bogotá, Colombia",
+                        },
+                        "units": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"],
+                            "description": "Units the temperature will be returned in.",
+                        },
+                    },
+                    "required": ["location", "units"],
+                },
+            }
+        ],
+        max_tokens=200,
+        stream=True,
+    )
+
+    chunks = []
+    for chunk in stream:
+        chunks.append(chunk)
+
+    assert len(chunks) > 0
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 200,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.id": "msg_01UWHNFBLJLDBkSePZiWAuWW",
+                "gen_ai.response.finish_reasons": ("tool_use",),
+                "gen_ai.usage.input_tokens": 389,
+                "gen_ai.usage.output_tokens": 87,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "What's the weather in Tokyo today?",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 0,
+                        "finish_reason": "tool_use",
+                        "message": '{"role": "assistant", "content": "Okay, let me check the weather for you in Tokyo today:"}',
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 1,
+                        "finish_reason": "tool_use",
+                        "message": '{"role": "assistant", "tool_calls": [{"id": "toolu_01DL5y2R7EpDetYdavzqrn9s", "type": "function", "function": {"name": "get_weather", "arguments": "{\\"location\\": \\"Tokyo, Japan\\", \\"units\\": \\"celsius\\"}"}}]}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_tool_message_with_tool_use_id(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test message with tool use and tool result."""
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[
+            {"role": "user", "content": "What's 2+2?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_test123",
+                        "name": "calculate",
+                        "input": {"expression": "2+2"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_test123",
+                        "content": "4",
+                    }
+                ],
+            },
+        ],
+        max_tokens=100,
+    )
+
+    assert response.content
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 100,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("end_turn",),
+                "gen_ai.response.id": "msg_01MY8XWnMDGTHugXs7zNn1QA",
+                "gen_ai.usage.input_tokens": 80,
+                "gen_ai.usage.output_tokens": 18,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "What's 2+2?",
+                    },
+                },
+                {
+                    "name": "gen_ai.assistant.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "tool_calls": '[{"id":"toolu_test123","type":"function","function":{"name":"calculate","arguments":"{\\"expression\\":\\"2+2\\"}"}}]',
+                    },
+                },
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {"gen_ai.system": "anthropic"},
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","content":"The result of 2 + 2 is 4."}',
+                        "index": 0,
+                        "finish_reason": "end_turn",
+                    },
+                },
+            ],
+        }
+    )
+
+
+def test_preserves_method_signatures() -> None:
+    """Test that instrumentation preserves original method signatures."""
+    fresh_client = Anthropic(api_key="test")
+    original_create_sig = inspect.signature(fresh_client.messages.create)
+
+    instrumented_client = Anthropic(api_key="test")
+    instrument_anthropic(instrumented_client)
+
+    assert inspect.signature(instrumented_client.messages.create) == original_create_sig
+
+
+def test_multiple_clients_independent(anthropic_api_key: str) -> None:
+    """Test that multiple clients can be instrumented independently."""
+    client1 = Anthropic(api_key=anthropic_api_key)
+    client2 = Anthropic(api_key=anthropic_api_key)
+
+    assert not isinstance(client1.messages.create, FunctionWrapper)
+    assert not isinstance(client2.messages.create, FunctionWrapper)
+
+    instrument_anthropic(client1)
+
+    assert isinstance(client1.messages.create, FunctionWrapper)
+    assert not isinstance(client2.messages.create, FunctionWrapper)
+
+
+@pytest.mark.vcr()
+def test_error_handling(client: Anthropic, span_exporter: InMemorySpanExporter) -> None:
+    """Test error handling and span error recording."""
+    with pytest.raises(NotFoundError):
+        client.messages.create(
+            model="invalid-model-name",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=50,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat invalid-model-name",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "invalid-model-name",
+                "gen_ai.request.max_tokens": 50,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "error.type": "NotFoundError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Error code: 404 - {'type': 'error', 'error': {'type': 'not_found_error', 'message': 'model: invalid-model-name'}}",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {"gen_ai.system": "anthropic", "content": "Hello"},
+                }
+            ],
+        }
+    )
+
+
+def test_client_marked_as_instrumented() -> None:
+    """Test that client is marked as instrumented after instrumentation."""
+    client = Anthropic(api_key="test")
+
+    assert not hasattr(client, "_lilypad_instrumented")
+
+    instrument_anthropic(client)
+
+    assert hasattr(client, "_lilypad_instrumented")
+    assert client._lilypad_instrumented is True  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_instrumentation_idempotent() -> None:
+    """Test that instrumentation is truly idempotent."""
+    client = Anthropic(api_key="test")
+
+    instrument_anthropic(client)
+    first_create = client.messages.create
+
+    instrument_anthropic(client)
+    second_create = client.messages.create
+
+    assert second_create is first_create
+
+
+def test_async_instrumentation_idempotent() -> None:
+    """Test that async instrumentation is truly idempotent."""
+    client = AsyncAnthropic(api_key="test")
+
+    instrument_anthropic(client)
+    first_create = client.messages.create
+
+    instrument_anthropic(client)
+    second_create = client.messages.create
+
+    assert second_create is first_create
+
+
+def test_preserves_async_nature() -> None:
+    """Test that async methods remain async after patching."""
+    client = AsyncAnthropic(api_key="test")
+
+    create_result_before = client.messages.create(
+        model="test", messages=[], max_tokens=10
+    )
+    assert inspect.iscoroutine(create_result_before)
+    create_result_before.close()
+
+    instrument_anthropic(client)
+
+    create_result_after = client.messages.create(
+        model="test", messages=[], max_tokens=10
+    )
+    assert inspect.iscoroutine(create_result_after)
+    create_result_after.close()
+
+
+def test_sync_message_creation_api_connection_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test sync message creation with APIConnectionError."""
+    mock_client = Mock(spec=Anthropic)
+
+    mock_request = Mock()
+    mock_request.url = "https://api.anthropic.com/v1/messages"
+
+    original_create = Mock(
+        side_effect=APIConnectionError(
+            message="Connection failed", request=mock_request
+        )
+    )
+    mock_client.messages.create = original_create
+
+    instrument_anthropic(mock_client)
+
+    with pytest.raises(APIConnectionError):
+        mock_client.messages.create(
+            model="claude-3-haiku-20240307",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=50,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.system": "anthropic",
+                "error.type": "APIConnectionError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Connection failed",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_message_creation_api_connection_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test async message creation with APIConnectionError."""
+    mock_client = Mock(spec=AsyncAnthropic)
+
+    async def create_error(*args, **kwargs):
+        mock_request = Mock()
+        mock_request.url = "https://api.anthropic.com/v1/messages"
+        raise APIConnectionError(message="Connection failed", request=mock_request)
+
+    original_create = Mock(side_effect=create_error)
+    mock_client.messages.create = original_create
+
+    instrument_anthropic(mock_client)
+
+    with pytest.raises(APIConnectionError):
+        await mock_client.messages.create(
+            model="claude-3-haiku-20240307",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=50,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.system": "anthropic",
+                "error.type": "APIConnectionError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Connection failed",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+def test_sync_message_rate_limit_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test sync message creation with RateLimitError."""
+    mock_client = Mock(spec=Anthropic)
+
+    original_create = Mock(
+        side_effect=RateLimitError(
+            message="Rate limit exceeded",
+            response=Mock(status_code=429),
+            body={"error": {"message": "Rate limit exceeded"}},
+        )
+    )
+    mock_client.messages.create = original_create
+
+    instrument_anthropic(mock_client)
+
+    with pytest.raises(RateLimitError):
+        mock_client.messages.create(
+            model="claude-3-haiku-20240307",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=50,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.system": "anthropic",
+                "error.type": "RateLimitError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Rate limit exceeded",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_message_rate_limit_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test async message creation with RateLimitError."""
+    mock_client = Mock(spec=AsyncAnthropic)
+
+    async def create_error(*args, **kwargs):
+        raise RateLimitError(
+            message="Rate limit exceeded",
+            response=Mock(status_code=429),
+            body={"error": {"message": "Rate limit exceeded"}},
+        )
+
+    original_create = Mock(side_effect=create_error)
+    mock_client.messages.create = original_create
+
+    instrument_anthropic(mock_client)
+
+    with pytest.raises(RateLimitError):
+        await mock_client.messages.create(
+            model="claude-3-haiku-20240307",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=50,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.system": "anthropic",
+                "error.type": "RateLimitError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Rate limit exceeded",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+def test_sync_streaming_api_status_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test sync streaming with APIStatusError."""
+    mock_client = Mock(spec=Anthropic)
+
+    original_create = Mock(
+        side_effect=APIStatusError(
+            message="Internal server error",
+            response=Mock(status_code=500),
+            body={"error": {"message": "Internal server error"}},
+        )
+    )
+    mock_client.messages.create = original_create
+
+    instrument_anthropic(mock_client)
+
+    with pytest.raises(APIStatusError):
+        mock_client.messages.create(
+            model="claude-3-haiku-20240307",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=50,
+            stream=True,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.system": "anthropic",
+                "error.type": "APIStatusError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "Internal server error",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+def test_sync_wrapping_failure_create(
+    caplog: pytest.LogCaptureFixture,
+    readonly_mock: Mock,
+) -> None:
+    """Test sync client when wrapping create method fails."""
+    mock_client = Mock(spec=Anthropic)
+    mock_client.messages = readonly_mock
+
+    with caplog.at_level("WARNING"):
+        instrument_anthropic(mock_client)
+
+    assert hasattr(mock_client, "_lilypad_instrumented")
+    assert mock_client._lilypad_instrumented is True
+    assert "Failed to wrap Messages.create: AttributeError" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_wrapping_failure_create(
+    caplog: pytest.LogCaptureFixture,
+    readonly_mock: Mock,
+) -> None:
+    """Test async client when wrapping create method fails."""
+    mock_client = Mock(spec=AsyncAnthropic)
+    mock_client.messages = readonly_mock
+
+    with caplog.at_level("WARNING"):
+        instrument_anthropic(mock_client)
+
+    assert hasattr(mock_client, "_lilypad_instrumented")
+    assert mock_client._lilypad_instrumented is True
+    assert "Failed to wrap AsyncMessages.create: AttributeError" in caplog.text
+
+
+def test_package_not_found_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test handling of PackageNotFoundError when determining lilypad-sdk version."""
+    with patch(
+        "lilypad._internal.otel.anthropic.instrument.version",
+        side_effect=PackageNotFoundError("Package lilypad-sdk not found"),
+    ):
+        mock_client = Mock(spec=Anthropic)
+
+        with caplog.at_level("DEBUG"):
+            instrument_anthropic(mock_client)
+
+        assert hasattr(mock_client, "_lilypad_instrumented")
+        assert mock_client._lilypad_instrumented is True
+        assert "Could not determine lilypad-sdk version" in caplog.text
+        assert isinstance(mock_client.messages.create, FunctionWrapper)
+
+
+@pytest.mark.vcr()
+def test_user_structured_content_is_jsonified(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test that structured user content is properly JSONified in events."""
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Reply with OK"},
+                ],
+            }
+        ],
+        max_tokens=5,
+    )
+    assert isinstance(response, Message)
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 5,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("end_turn",),
+                "gen_ai.response.id": "msg_01HvUTzuJrpuw4iM6JEVfCrg",
+                "gen_ai.usage.input_tokens": 10,
+                "gen_ai.usage.output_tokens": 4,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Reply with OK",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","content":"OK"}',
+                        "index": 0,
+                        "finish_reason": "end_turn",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_message_with_advanced_params(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test message creation with top_p, top_k, and stop_sequences parameters."""
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Count from 1 to 10"}],
+        max_tokens=50,
+        temperature=0.5,
+        top_p=0.9,
+        top_k=40,
+        stop_sequences=["5", "STOP"],
+    )
+
+    assert isinstance(response, Message)
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.request.temperature": 0.5,
+                "gen_ai.request.top_p": 0.9,
+                "gen_ai.request.top_k": 40,
+                "gen_ai.request.stop_sequences": ("5", "STOP"),
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("stop_sequence",),
+                "gen_ai.response.id": "msg_01DNgVygQxNYvEasAop9YxPk",
+                "gen_ai.usage.input_tokens": 15,
+                "gen_ai.usage.output_tokens": 14,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Count from 1 to 10",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","content":"1, 2, 3, 4, "}',
+                        "index": 0,
+                        "finish_reason": "stop_sequence",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_multiple_content_blocks_in_response(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test response with multiple content blocks (text and tool use)."""
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[
+            {
+                "role": "user",
+                "content": "Use the calculator to add 2+2, then explain the result",
+            }
+        ],
+        tools=[
+            {
+                "name": "calculator",
+                "description": "A simple calculator",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "operation": {"type": "string", "enum": ["add", "subtract"]},
+                        "a": {"type": "number"},
+                        "b": {"type": "number"},
+                    },
+                    "required": ["operation", "a", "b"],
+                },
+            }
+        ],
+        max_tokens=200,
+    )
+
+    assert isinstance(response, Message)
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 200,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("tool_use",),
+                "gen_ai.response.id": "msg_01KV2iLqmFG9x2eP5pUYjPov",
+                "gen_ai.usage.input_tokens": 369,
+                "gen_ai.usage.output_tokens": 85,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Use the calculator to add 2+2, then explain the result",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","tool_calls":[{"id":"toolu_01YFd3xn1WU8TvvRaEZJo2A9","type":"function","function":{"name":"calculator","arguments":"{\\"a\\":2,\\"b\\":2,\\"operation\\":\\"add\\"}"}}]}',
+                        "finish_reason": "tool_use",
+                        "index": 0,
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_async_streaming_with_multiple_blocks(
+    async_client: AsyncAnthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test async streaming with multiple content blocks."""
+    stream = await async_client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[
+            {
+                "role": "user",
+                "content": "First say hello, then use a tool to get weather",
+            }
+        ],
+        tools=[
+            {
+                "name": "get_weather",
+                "description": "Get weather for a location",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"},
+                    },
+                    "required": ["location"],
+                },
+            }
+        ],
+        max_tokens=200,
+        stream=True,
+    )
+
+    chunks = [chunk async for chunk in stream]
+    assert len(chunks) > 0
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 200,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("tool_use",),
+                "gen_ai.response.id": "msg_017g5nGzRt4EZ99PJCL3mPcV",
+                "gen_ai.usage.input_tokens": 335,
+                "gen_ai.usage.output_tokens": 56,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "First say hello, then use a tool to get weather",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 0,
+                        "finish_reason": "tool_use",
+                        "message": '{"role": "assistant", "tool_calls": [{"id": "toolu_012Ve9LFLZeA5nuaqr4CXMrU", "type": "function", "function": {"name": "get_weather", "arguments": "{\\"location\\": \\"New York, NY\\"}"}}]}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_assistant_message_with_empty_content(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test assistant message with empty content in conversation history."""
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[
+            {"role": "user", "content": "What's 5+5?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool_123",
+                        "name": "calculator",
+                        "input": {"operation": "add", "a": 5, "b": 5},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool_123",
+                        "content": "10",
+                    }
+                ],
+            },
+        ],
+        max_tokens=50,
+    )
+
+    assert isinstance(response, Message)
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 50,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("end_turn",),
+                "gen_ai.response.id": "msg_01PnwR192aksf1WmLLjQnQ2z",
+                "gen_ai.usage.input_tokens": 112,
+                "gen_ai.usage.output_tokens": 18,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "What's 5+5?",
+                    },
+                },
+                {
+                    "name": "gen_ai.assistant.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "tool_calls": '[{"id":"tool_123","type":"function","function":{"name":"calculator","arguments":"{\\"operation\\":\\"add\\",\\"a\\":5,\\"b\\":5}"}}]',
+                    },
+                },
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {"gen_ai.system": "anthropic"},
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","content":"The result of 5 + 5 is 10."}',
+                        "index": 0,
+                        "finish_reason": "end_turn",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_streaming_with_stop_sequence(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test streaming that stops due to stop sequence."""
+    stream = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Count from 1 to 10"}],
+        max_tokens=100,
+        stop_sequences=["5"],
+        stream=True,
+    )
+
+    chunks = list(stream)
+    assert len(chunks) > 0
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 100,
+                "gen_ai.request.stop_sequences": ("5",),
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.id": "msg_01MkwFJN43cbW1dV6aLXEoH9",
+                "gen_ai.response.finish_reasons": ("stop_sequence",),
+                "gen_ai.usage.input_tokens": 15,
+                "gen_ai.usage.output_tokens": 14,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Count from 1 to 10",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 0,
+                        "finish_reason": "stop_sequence",
+                        "message": '{"role": "assistant", "content": "1, 2, 3, 4, "}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_structured_user_content_as_text(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test that non-list user content is properly handled."""
+    response = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[
+            {
+                "role": "user",
+                "content": "Simple text message",
+            }
+        ],
+        max_tokens=5,
+    )
+    assert isinstance(response, Message)
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 5,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.finish_reasons": ("max_tokens",),
+                "gen_ai.response.id": "msg_01ULUU4JsTPuhYDUbYWp7Nfj",
+                "gen_ai.usage.input_tokens": 10,
+                "gen_ai.usage.output_tokens": 5,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Simple text message",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "message": '{"role":"assistant","content":"Okay, I\'m"}',
+                        "index": 0,
+                        "finish_reason": "max_tokens",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_streaming_tool_use_detailed(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test streaming with tool use to ensure input_json_delta events are captured."""
+    stream = client.messages.create(
+        model="claude-3-5-sonnet-20241022",
+        messages=[
+            {"role": "user", "content": "Calculate 123 * 456 using the calculator tool"}
+        ],
+        tools=[
+            {
+                "name": "calculator",
+                "description": "Performs basic arithmetic",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "operation": {
+                            "type": "string",
+                            "enum": ["multiply", "add", "subtract", "divide"],
+                        },
+                        "a": {"type": "number"},
+                        "b": {"type": "number"},
+                    },
+                    "required": ["operation", "a", "b"],
+                },
+            }
+        ],
+        max_tokens=200,
+        stream=True,
+    )
+
+    chunks = list(stream)
+    assert len(chunks) > 0
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-5-sonnet-20241022",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-5-sonnet-20241022",
+                "gen_ai.request.max_tokens": 200,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-5-sonnet-20241022",
+                "gen_ai.response.id": "msg_01EP6EGGKpKQNgBtecdZ2RxB",
+                "gen_ai.response.finish_reasons": ("tool_use",),
+                "gen_ai.usage.input_tokens": 423,
+                "gen_ai.usage.output_tokens": 103,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Calculate 123 * 456 using the calculator tool",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 0,
+                        "finish_reason": "tool_use",
+                        "message": '{"role": "assistant", "content": "I\'ll help you multiply 123 by 456 using the calculator tool."}',
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 1,
+                        "finish_reason": "tool_use",
+                        "message": '{"role": "assistant", "tool_calls": [{"id": "toolu_01HfCf8ib3nRGcpqyyQ46gqF", "type": "function", "function": {"name": "calculator", "arguments": "{\\"operation\\": \\"multiply\\", \\"a\\": 123, \\"b\\": 456}"}}]}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_streaming_with_input_json_delta(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test that input_json_delta chunks are properly processed during tool streaming."""
+    stream = client.messages.create(
+        model="claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "Use the calculator to compute 42 * 17"}],
+        tools=[
+            {
+                "name": "calculator",
+                "description": "Performs calculations",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "expression": {"type": "string"},
+                    },
+                    "required": ["expression"],
+                },
+            }
+        ],
+        max_tokens=300,
+        stream=True,
+    )
+
+    chunks = list(stream)
+    assert len(chunks) > 0
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-5-sonnet-20241022",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-5-sonnet-20241022",
+                "gen_ai.request.max_tokens": 300,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-5-sonnet-20241022",
+                "gen_ai.response.id": "msg_01MVpyWMCxqqTBM4o9uyYJ49",
+                "gen_ai.response.finish_reasons": ("tool_use",),
+                "gen_ai.usage.input_tokens": 380,
+                "gen_ai.usage.output_tokens": 75,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Use the calculator to compute 42 * 17",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 0,
+                        "finish_reason": "tool_use",
+                        "message": '{"role": "assistant", "content": "I\'ll help you calculate 42 multiplied by 17 using the calculator tool."}',
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 1,
+                        "finish_reason": "tool_use",
+                        "message": '{"role": "assistant", "tool_calls": [{"id": "toolu_016GFtMEs6NRjMteg9c9fE4v", "type": "function", "function": {"name": "calculator", "arguments": "{\\"expression\\": \\"42 * 17\\"}"}}]}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_streaming_max_tokens_stop_reason(
+    client: Anthropic, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test streaming that stops due to max_tokens limit."""
+    stream = client.messages.create(
+        model="claude-3-haiku-20240307",
+        messages=[{"role": "user", "content": "Write a very long story about a robot"}],
+        max_tokens=10,
+        stream=True,
+    )
+
+    chunks = list(stream)
+    assert len(chunks) > 0
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat claude-3-haiku-20240307",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "claude-3-haiku-20240307",
+                "gen_ai.request.max_tokens": 10,
+                "server.address": "api.anthropic.com",
+                "gen_ai.system": "anthropic",
+                "gen_ai.response.model": "claude-3-haiku-20240307",
+                "gen_ai.response.id": "msg_018dfAvKYnjmrx6J8ppbmj5u",
+                "gen_ai.response.finish_reasons": ("max_tokens",),
+                "gen_ai.usage.input_tokens": 15,
+                "gen_ai.usage.output_tokens": 10,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "content": "Write a very long story about a robot",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "anthropic",
+                        "index": 0,
+                        "finish_reason": "max_tokens",
+                        "message": '{"role": "assistant", "content": "Here is a very long story about a robot:"}',
+                    },
+                },
+            ],
+        }
+    )

--- a/sdks/python/tests/lilypad/_internal/otel/conftest.py
+++ b/sdks/python/tests/lilypad/_internal/otel/conftest.py
@@ -1,0 +1,56 @@
+"""Common fixtures for OpenTelemetry instrumentation tests.
+
+This module provides shared fixtures that can be used across all OTel test modules.
+"""
+
+from typing import Generator
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.trace import ProxyTracerProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from .test_utils import ReadOnlyPropertyMock, PartialReadOnlyPropertyMock
+
+
+@pytest.fixture
+def readonly_mock():
+    """Fixture providing a mock with all read-only properties."""
+    return ReadOnlyPropertyMock()
+
+
+@pytest.fixture
+def partial_readonly_mock():
+    """Fixture providing a mock with mixed writable and read-only properties."""
+    return PartialReadOnlyPropertyMock()
+
+
+@pytest.fixture
+def span_exporter() -> Generator[InMemorySpanExporter, None, None]:
+    """Set up InMemorySpanExporter for testing span content.
+
+    Yields:
+        InMemorySpanExporter instance that captures spans
+    """
+    current_provider = trace.get_tracer_provider()
+    if isinstance(current_provider, ProxyTracerProvider):
+        provider = TracerProvider()
+        trace.set_tracer_provider(provider)
+    else:
+        provider = current_provider
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+    provider.add_span_processor(processor)  # type: ignore[attr-defined]
+
+    exporter.clear()
+    yield exporter
+    exporter.clear()
+
+
+__all__ = [
+    "partial_readonly_mock",
+    "readonly_mock",
+    "span_exporter",
+]


### PR DESCRIPTION
### TL;DR

Added comprehensive test coverage for Anthropic instrumentation in the Lilypad SDK.

### What changed?

- Added test files and cassettes for Anthropic instrumentation
- Added pragmas to exclude unreachable code paths from coverage
- Fixed a bug in the response finish reasons attribute (changed from list to tuple)
- Refactored test utilities to create shared fixtures for OpenTelemetry tests
- Added additional headers to filter in VCR configuration

### How to test?

Run the test suite with:
```bash
cd sdks/python
pytest tests/lilypad/_internal/otel/anthropic/
```

The tests cover various scenarios including:
- Sync and async message creation
- Streaming responses
- Tool usage
- Error handling
- Multiple content blocks
- Stop sequences

### Why make this change?

This change completes the test coverage for the Anthropic instrumentation module, ensuring that all code paths are properly tested. The shared test utilities also improve code reuse between the OpenAI and Anthropic test suites, making the codebase more maintainable.