### PR TITLE
Add unit tests for Google OpenTelemetry integration in Lilypad v1

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -164,6 +164,9 @@ addopts = ["-v"]
 asyncio_mode = "auto"
 markers = ["vcr: Mark test to use VCR.py for HTTP request recording/playback"]
 
+[tool.inline-snapshot]
+format-command="ruff check --fix-only --stdin-filename {filename} | ruff format --stdin-filename {filename}"
+
 [tool.coverage.run]
 branch = false
 source = ["src/lilypad"]

--- a/sdks/python/src/lilypad/_internal/otel/utils.py
+++ b/sdks/python/src/lilypad/_internal/otel/utils.py
@@ -234,6 +234,14 @@ class StreamWrapper(BaseStreamWrapper[ChunkT, MetadataT], Generic[ChunkT, Metada
             self.cleanup()
             raise
 
+    def __getattr__(self, name: str) -> Any:
+        """Proxy attribute access to the underlying stream.
+
+        This allows access to stream-specific attributes like text_stream
+        for Anthropic's MessageStream.
+        """
+        return getattr(self.stream, name)
+
 
 class AsyncStreamWrapper(
     BaseStreamWrapper[ChunkT, MetadataT], Generic[ChunkT, MetadataT]
@@ -309,6 +317,14 @@ class AsyncStreamWrapper(
             )
             self.cleanup()
             raise
+
+    def __getattr__(self, name: str) -> Any:
+        """Proxy attribute access to the underlying stream.
+
+        This allows access to stream-specific attributes like text_stream
+        for Anthropic's MessageStream.
+        """
+        return getattr(self.stream, name)
 
 
 class ToolCallBuffer:

--- a/sdks/python/tests/conftest.py
+++ b/sdks/python/tests/conftest.py
@@ -60,6 +60,13 @@ class VCRConfig(TypedDict):
     Useful for removing sensitive data from request bodies.
     """
 
+    filter_query_parameters: list[str]
+    """Query parameters to filter out from recordings.
+    
+    Filters out specified query parameters from the URL.
+    Useful for removing API keys that are passed as query parameters.
+    """
+
     before_record_response: Callable[[Response], Response]
     """Callback to modify response before recording.
     
@@ -101,7 +108,7 @@ def vcr_config() -> VCRConfig:
     Uses session scope since VCR configuration is static and can be shared
     across all test modules in a session. This covers all major LLM providers:
     - OpenAI (authorization header)
-    - Google/Gemini (x-goog-api-key header)
+    - Google/Gemini (x-goog-api-key header, key query parameter)
     - Anthropic (x-api-key, anthropic-organization-id headers)
 
     Returns:
@@ -126,5 +133,6 @@ def vcr_config() -> VCRConfig:
             "x-stainless-runtime-version",
         ],
         "filter_post_data_parameters": [],
+        "filter_query_parameters": ["key"],
         "before_record_response": _filter_response_headers,
     }

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_async_generate_content_simple.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_async_generate_content_simple.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Say hello back to me"}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '77'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61R0U6DMBR95yuwz2NBYI756kzUbBEcWUzUh07uoLG0hHZkhuzfbWGwoq/2oWnu
+        Ob3nnnMby7bRJ2YpSbEEgW7tN1Wx7aa9NcaZBCYV0JdUscSVvHC70xhvRZFw1J/QA1DKr94ZMuDT
+        8P6YXJpWnIL+UfAUaE8/9QS0J4yI/AWw4EzTNslzhAYU19mKZ2XFd3oux51e++F8vvA8b3Ez8wI3
+        CK1eudVEB4EzWIPEyjce3CHVoShlwr+A3fFD63vWiRgpjWD/DEsuMR0h4eRPT7FUioSa2RmxKueY
+        Evmt7SX3rwky0pGjkfp0LCPE3wP+k5Y/1rLOO+nWtIVKkG4fGRRqQ443dZ09xSJ34Fi2TVEFouRM
+        wGOqefFuA3i9jJ8ip2Z1FpFolQexQNbJ+gH8SzBHjQIAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:14:57 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=526
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_error_handling.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_error_handling.yaml
@@ -1,0 +1,59 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Hello"}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '62'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/invalid-model-name:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/52RwUvDMBTG7/0rHj3PuIMnTxYsUtzGUCeISHk0byHYJiXJCnP0fzdJ4+g87pS8
+        L1++/N7LKQPIyRht8ns4+cKXjebkq7vlcjEJHVmLImh5sa3gm46gtIMBW8kZbFtCS9CjtYCTCMnG
+        8pRgHbqDDQHV5r1YVY918fK0W5ebtz8HJ4eyDZbPKECiiYcP7tjH58PKhNbCv9lLyxrd3U4lM33D
+        ytBIpfY6pcbLxuNpleDr5/KjTgxzE9cdymi6TJ97Oo/I0eF5Ukm3ZAbZRD5Bigw6OVCLShz80P7R
+        5ueLY9qNi+v7XenGj/uH+Dr90Iy2DWcxhNTN7vWykav/M5vDf2VhN2a/7rke3kUCAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:15:00 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=141
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_base64_string_inline_data.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_base64_string_inline_data.yaml
@@ -1,0 +1,70 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Analyze this base64 encoded image"},
+      {"inlineData": {"data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+      "mimeType": "image/png"}}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '241'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/41U227bMAx9z1cQftkWOFmXJVnRt/WCNsCKZW2wDViHgrYZW6gsGZKcC4r++ygr
+        TtwOHRYkjiEeHV4OycceQJSiykSGjmx0Ar/4BOCxeXqbVo6UY0N7xIcVGnfAhs9j550hjjb+UnRF
+        ht5YQMVflFsrLOgluIJAlJjTyZ26U/3+OdnUiMoJrU76fX+2aBHANxCsliKLoVZiqU0JiawJUi21
+        GQIjDQHyT2mo0DkyysZgC6yI/7WBFRqBntuCUO21mdsxi7KSFMNSogs2WAophyGwM3/QCSkAsKoI
+        jQWnIWHXkBiRF459oqsN1zFrAhzCD+EKXTuwFaViKdLd9RWy1cLbm8vTGK5oEwO5dPguBuG4VByP
+        tlYkkjx/RkuhuAgOKsMkluQ2hoQ5G6wUD3zAEVSGi2W2wW8Ifd6yzFhBw7ddqMH7My/pxu2y6rNa
+        DJaYUqFlRj5bX5zSpxTSqw7GVhOWE9aUWOEIQkGkSBt+WDd6eIUxdTXKg4yl4IhUPmydnmL6kBtd
+        q8z7PCie6lpm3nVtuZToVUr20F0NmwgysiJXe77bNbq0aOPHLRjitC23L2PDNdtAurd9+MFWoSTu
+        nj3dgqyDWdOlgXIfV9s14DwkBM1apQWlDzuyTFgu29azB3tldEpN/rCsVdpIsVNqpsDWpdcvPkxG
+        6M4VeVHRcu+shPXVJEklZ3TSDkWYBe4NhyqXNPSqRp1ZfNq//44PE2y0JD+epc5ItvCnFhBxzwlb
+        3BBarTzsdvF1Hu2tuMq/6JwTSvwSGBwNJ8fj8Xg6PZ6OxqOjD+OPk17rufEZ1ZYTuuYG5CWD+1US
+        MUNZuYV+IHXG0vp9MZpOgpvOUnoOOPq4AzjtUD6zjafH8V/M9pz9CtldV51NxvmjFG7rk5xdf768
+        iDpFcs8cT45flukVnsXFz8WrNJ9akl5HkpfJ/n/M//TFtXrurbcLPsj+nYwVQd+cSlZ8MBoeDXgP
+        2mJAm6qhjXh+Ku5UmmUed2EHhNclnd2bRK3y+f38cjn6to56T70/VupNfEoGAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 06:09:23 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=2012
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_dict_tools.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_dict_tools.yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Search for AI news"}], "role": "user"}],
+      "tools": [{"functionDeclarations": [{"description": "Search for information
+      in database", "name": "search_database", "parameters": {"properties": {"query":
+      {"type": "STRING"}, "limit": {"type": "INTEGER"}}, "required": ["query"], "type":
+      "OBJECT"}}, {"description": "Get user information", "name": "get_user_info",
+      "parameters": {"properties": {"user_id": {"type": "STRING"}}, "required": ["user_id"],
+      "type": "OBJECT"}}]}], "generationConfig": {"temperature": 0.5}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '542'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61R0U6DMBR95ytIn8fSCTLnm5k+LHFuOmJMjDF348IaS4ttmZpl/26BscHUN/vQ
+        lHsO59x7z9ZxXbICEbMYDGpy6T7biutuq7vEpDAojAWaki3moMyRW59t620pSSFWhkkxBs47P+9x
+        ARnaOtEIarV+te6wBI2kd0oElepfBCzyXqD6KjWuJq7AD01OKDvnr6/j++XoR5TkVUuZjJE3YruG
+        QBImmF4/IGgpStoims0P7RLYpLcyzZVclt16tE8pPR9SnwYXwZAOBqPQD0ZOY17ZkkJDilM0UE5/
+        mJFYkSw3kXxDMZZFtXs/qI1aUXXwcA8baYB3kID2fqjqa+vJeDvBVrh2fODMVJuNbp6iViRWv9NU
+        syOntcrTFv/JLOx6Oftk6rAeUWlWp5JiZnPyzvrUSzjotYefeSVKFOpcCo2TuORdrGYIU/TvChaL
+        TToX4SJJ7ylxds43KZK9CRQDAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 05:21:54 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=639
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_inline_data_bytes.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_inline_data_bytes.yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What is in this image?"}, {"inlineData":
+      {"data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+      "mimeType": "image/png"}}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '230'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61RUWvCMBB+768IebYyO211b2MTERTdVsZgjBHttYaluZJE5xD/+9LWanT4tjwc
+        4e6777v7bucRQpdMJjxhBjS9I+82Q8iuimUNpQFpbKFJ2WTBlDlh67dz/hZiYFs20XgFhOcss1ET
+        RjQKnpCFWANZokDVpk7b/vj/aJ3EFAoomXJMQDTwfQOgKZdcr56BaZQl7CWezemxyjbZBLNC4aKc
+        179p3/Y6UdgddKNO1BtEg7DjNcqVJl1rO+sUDLN+sOPW1DLkhYnxC+QDris/grBbyzj+nQH6h7JB
+        w8R5axS0/vDqR6vKheurY7ndnglufipPh28xdRwyLnd46dAVkvH0fjS8yhL0+g2P5xzkctV/mvlC
+        yztMX5/8FZTm9W0zyO21/aB946eC6ZUP26IipQp0gVLDOClx/ekM2CxNJhu1kJts/jkfpcHTN/X2
+        3i9QujuY8QIAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 05:21:53 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=1027
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_mixed_content_types.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_mixed_content_types.yaml
@@ -1,0 +1,347 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Simple string content"}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '78'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61RXU/CMBR9369o+syWjQ8BX9UYUAPKQkjUh+ouo6Frm7YjEMJ/t90YdPrqHprm
+        nrNzbs85Bgjhb8IzmhEDGt+idztB6FidDhPcADcWaEZ2KIkyV279Hb27pRjYu5/wbEsOHTRBJc9A
+        aWOdIjQttUEEaVpIBkgbRXkefXDsKZwu98/O1VcJBk60EBmwhn5qCHhNOdWbNyBacEdbpLM5vqBk
+        lz+LXCrx5VYP4ygZj3uD4WB800viYdzt9oPGufLEpSY5vIAhNhpyCQBbhUKaVGyB34myiqZXm3hB
+        tuAkOeNGGMLaUL/zR1XfW0/K/IC97O3bCaPm4B6YPqxS7OVjWks1+QRejL9X/CevJGmbBeda6qaW
+        tnlaV5JDYUsKu1EcrhnRmxD2slLFCrQUXMMkc7ytokCeHlez6ULwXT4fDQ9y9DrBwSn4Afe5Cyez
+        AgAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:33:23 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=501
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Content object with Part"}], "role":
+      "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '81'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/8VaW3PbNhZ+z6/AqA+RvbKa2GmbyUym47Xbxlsn8cRO067tsSASkhBTBEuQVtSM
+        //t+5wAgQUlOnGxn1w8JBYIH54bvXICPD4ToJTJPdSorZXvPxDlGhPjI/9I7k1cqr/AiDGGwkGXV
+        znV/H6NnTKnUB/qo9/paLgfiSNR5qkpbYaWh+MPUYiHzSlRGpMompR4rIYVfSpjxe5Xg5UxWQudJ
+        VmMOXl/0TrDsRW8ozmbaCm35k/nc5KKQVaXKHLOFNZNqIUsFwjcqM8WcKGLVhvpc5nKqeNgubaXm
+        VvQPXp5uiYkpha3KOqnqUudTol1k6oOAYiRTkFlmFvSGZs5NWmey1NWS35WqtnKsM/weXuQX+QtV
+        qofE4bhU8jo1i1yYiViQSCzXXE9nlciMuRaZvlYDEDegvNDVTKR6MsHnYHAhl1Ysoa3E1BkYKIrS
+        yGQmdDWAfIWC2fARFFDNlLCFSvREJ07SD9Uz4mN7+22jeJpLEw9MnqiistvbPAPW2t4+8Np5zbp/
+        to3RM0w1N6qUZTLDpwNRlHouy6UotEoUicOaAXsPoe5SFaWyIIGp3kKOaTJtLmA5nWQkJ8hAdbBv
+        ATPQ79QkNZmDnjNlrcnpaZyZqSiMxTC0LfNlRUwIq+caah8KcVSJmbRErVAgDhdhxaZqonMFDVnH
+        fJY1RlVsqbmqJDE+bIUnvxJ9LHMAk5uceXlJ9gV/p1CHNvkWq2Rf2DkoqnIgrMomO6RpieVSuLeu
+        SCXBy5yR5TXYqgvWOrieqnLFyYekZp1f06cgIMljnCtlSoxrnbHRoIvkeih++iDJI1vFwsK010iI
+        fTFTkibHQ9imclrKYkbkySWil9gscxggnn6jU2WEmo9VGg8nJoVz5booVExA/Fnrv/CPsqSf+EVF
+        3Dvne0cOjF3+JngHqyLsZAxnkr62M104b6R9I2j7+p298ATKiABc66K3Aha8cQpHtYyodjYW1tYl
+        eYwNiGB5kzwekhf8RIKnsCUxB1A41aRtcaxt9e1+Wcol+cBFJOn29iGDV0GLkX/Qjlnha8YmzUCD
+        3ZjIeD/VJd5nS+F9yHrNeBnc53YYr+btL/on2Awm3yHgiHmiv9FoVPDbdijJpLUs1LN2kP6wVcTV
+        lYbnXl31yZ8HoloW8HkvA+08YMfzV9gSWyvf0h99MqQvxHP+UIhvhBpOhwOIEbyxN3AyOT90P53j
+        9e4gGBT4vFHlN2If21dmzUCffHkg3r45HghVJcOtO0gx+yDk/gedE2M1GYvdQTvY7BrsYk1xHhk9
+        MH5eg7oi2OAI+RnN0UxSHf1/xxwmgznufz0JD1bkphJEXqjMKnF+GTP+TYAK8dY2e5z+PAqDYEeq
+        PrPw/KL3cin2F8qauRL7bupFb2vtc8fVENEIAahPjtUn8z/vWN2rFYNHeeUQn2CiF5zq8daXEO54
+        UEs6JAJkx4lGlGshb9gutftFS3nvjJfhoeH7YtrS3ItpYtN1ceEEEEOA4CEE+MUPTS7SJkNwYI7b
+        iCpLzism+gMgCA8OxZDDLF3QEXkNgCotYbljPl7xgLAMKx4g1o5VQhakWOqzHQ4nDIH4vfSfC3Fo
+        lM0fRlhk66IwiIUh9YmR1IJutVAq9z7Yd1s9B/6DYR7bGorXpB2KWS7ByRXeQXwkAepDkelE0zKO
+        qdRxBIZHrNNRiOVLsHZMzE/AgybWJ6yPndoSZbe8TKBjyFdnlSYdd7ex5ei+y7j+RnE2lbTI/pbp
+        HB3ab39VS/s1sG4rU6oW2Sdiuwyr2O2gGiywRcJbRV5ZbUB3l2Q5geDDc+z5GyKL+McrpLy7FzMK
+        ip4oUEu2FCmRGUsAAMdczqY0bzTkaVv/6+Ch05UAcif06RQQpNPPh5T7xoi/E7avdPo3ITdR8uDN
+        jx6/3fN9IXzHe613CLZ/a+T2ixAqPnYZcj73+AK1GKOcTp83Q85c98PtrcEmurvrdHcjup+BbdmB
+        680r7K2vsBetcCdaFyROhNG3sXa/Jg5GznEeaTASuuHucqtryjOUudoWGed+KqweeRfhm6fOBo5i
+        FC244oc0HHKCcz/ncmUKMLjqT1yiLc6gK9TvNJU31+0gyB1GvfZuOyq7M6y9hCeugvMXYLPoU0n7
+        vgZyyjRllRwdElA2H4yC5CMGWAosYp+qb+trb1cgcIyK6vkQGQNWNuiIKqVEhThALcZtDloMKAqO
+        Mwe/LicHhmeE7mSCLFtj24moq62NkfdlzFQc8cH7G4ViiQIGMxvqcNrRYN33DypweIMkl0q1DZVA
+        g/mZazDscWw7K5USp01923/lojEjxmfjmgeWBBHYFyHCYGnnilBWUipJ5TxUNdO+D5DIqJ5uOzG2
+        1hyB2DydGpgKIOtqaJC09bj9Qan7/7e+gUBZiqh97xLn/vFo8zy/Hk0MjwgK7fOng8J/E9lKY6or
+        MqyXFbj0BkPO+30KXZliJ6O2maukvz74NYthXvO8MbzdH5O9a3+qLomXjVN673KfDG+foNaY7d4l
+        z+sbVd5otQDdryZ8R+xs2Dblkns6Q7dIuwz5AOM/r9GnfyhtTOn7R6tO7gIFYAaAg23opol/CISO
+        r4wa9McoQLIRlHYk3bDHIl551qDl4nFHsCaonZFLgImgUHaRLhcR0TW1b60AyuYgBw9NVJYRIy7C
+        tf3NBuFcAYN9qWTZYOQyhJ9kJosKFdugC4A74dfmOLIWSFyAWysUU6UKrr644dqGmATVw6TOqLGu
+        p3kIJxUFiha4SeQnHEH+dfr61Q4FyVT0f/YhfQAEEgcMNofUTnU9k1eo5VQaAfLGoNJ0+uyG7gqH
+        OmrN+jzBhvKRuGjZ86Xtxqhwj4CAyEtF7HtLgxF6OlauPCsbMmUHacg3OQNkntr0b1Nyamny+bpL
+        fwQtihZMqtMKC/GB33Qh6HbwGUIrbbQOqc0p9WaSa0Ne+mahFi/vmttZ++e65LThUCGHyOwnPmt1
+        hgjwKuocbP7gC1R5in3VvN0k9hdrlLdh6kQSVIGTPjfTvVwfXpkZzbjtxkFsewQLPgoLm6Dp4tMf
+        efEVH7Q85+dhWs8L2+86c4PvT1YhsN98v1KTHBuZiklp5puXzfBapVdtYsNr06i9k+R+kihrI3xc
+        5aVL9LzZcJcR16EUosixNt/7z+XGILah2jl/SLZ+eLkWus4feqJ4txa9kJE1S4UA9gzyvQB6AYjy
+        T/otnyLW46sgA692J+drEghBnhzLEYhtlKV9eYc8bXjrRrcXejqjQOIRH6HgJ2mXrltVIsjov1xd
+        gigSfg+JtyjND6ennOaHRt/M6UgiNKZK3EgUNdUyPhhrQZ6jp6mRgpbKndqlLsPt4n8TF7klyLm4
+        lROiioVzX5SF7zbEQeaIj0ldJOyGGjIRqtGST7nwueufut4pyp+UpeVjQ5RHVCI14mPXLpsw3Qld
+        dPD1q1qSmSy0ULoWqng3Q4Z/MDOGOcY6+/44t3sOywS1U1owNBnMLNpVUoJ6zzbP+BH1MYSpuFPo
+        HTSkGXj3TqOcdSVnkBvJSY7ac1JCXyCQLX8MLLxpj7KJBy4SiYNDw0fRwdJU8itHVM6jehUKvavw
+        b5ZousQx/SOXMbjDGm8slydQIkMn2xKCBhKnqEQ9l0E93NteLdrJdo7KgpQQS+ASq4biiSphVwwm
+        KlCEKyXX2CbpquhcrPsdEnV2gjUCyTOVzHKTmekSRbpMrtmP39F+geUReOZzUkIGS9TgxLYdCzwS
+        7QmmqIUpr11PmHhgf4dJT6k5FS4EUGeB++1wXW6O5BJGRqnOiTjCC9X2VWBGN14acqvTROXYquYZ
+        Hd/+k07eT4ytnF8eq+ohTAAJ/Ul/cywdDukzWZHihsJfephBc8SqYyl4yUWve8fAJc/+INhf4Hj2
+        yQsJI+KMGBuJ/pmravdrQEg5EIeywq9j34xn+KTue3zA70Bk9MIlCTQyGojRScgAwsARdQ/DjwOA
+        wqk7+eYhYu+P5jpGK9nqEQMkCqbxPf6I9wV/zO3c6AAB7CLFp8sdhdGuynBNqnCrgwNK3AReOVag
+        RbvHAXziLK7VcudGZrU/UmB+gB6OC77SwsZqdvTmFl5zHaNproEBOsCSZQoG9scE5KQMZxHw4uFn
+        y7vaLyqn2xjilxqQCDxWnesn+2Mgk0yazlSAzqgH5WcIls/jPfv3qNMvGPHGGbG53P0ivg/irxNA
+        s9jlMlEOGMZqJm+0KW2jFcIIurbRBgW3ofx1H/5KSYtSj4ij/EbZPozBO5ww0+UTcZQDkBEyPaSI
+        n+UN98faaf24b+pPpVdvQm05Ylzw6ZZi25RTDf9Tp2VAFkrSlPuc806zdi2UuTLRNjIcUqr5GwJ+
+        KhtrHDWHl5yI3jRvWQe5rTn0yKpT8bXAixHCB5rMWg3BPuojNo3EqMh1ZRxdE1tQ5EyV5DDOsAFH
+        LXecsBTq/JrsameGwJXuskCRLDyl8LxtSjoYhRyO+QGQS5EzNVfQ4ltUtqmcKeOIEpiokuUtSZuH
+        wJlgOvA3dCAvXUiOLnS5XjMoOv8jpPSTliRTevfFBDJxQ7QJBO42DD7oI+NSYzgVHQIWdNLqZeT7
+        EQhIveh63m3zfDloL/WVJlN0Yw+urrIw/TZM6FEfwM7eQGMmp2mnZ69Pes1beTM9NlMofkz3Ance
+        Dfce7T3d/eHJo++/+/7po6c/fPfkQViZ1+zVdDPhpb+L1dwu7IHCvKjOzLXKD0zN9w6fuEWiW4qd
+        17t7u4/9jMpUMlt9+d1gjbL1lWp0gzG63Aj5JaUVJOTZT7+f9SIdVR3Ggo4eRKpcZfNvWouk7C73
+        wBvH2es3VVrtDDNVyCr0zu7w0c4EMDnbUR8KpttDeloAWNVRynY+1kqeyD9fFHsqv5mePP3379mf
+        +7b34PbBfwDZgGcrFioAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:33:44 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=15836
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Dict-based content"}]}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '59'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61VTW/bRhC961cMeKkjSILqJmrsi5HaaSDAiYVGaRtURTEih+TWy11mdymZMfzf
+        M0OKFJU0t+ogrTiz8968+eDjCCCK0SQqwUA+uoS/+AnAY/MtNmsCmcCG7hE/LNGFo2/7eRyc2SXQ
+        g1yK7u6xnsASKpOQ84GRZvDRVrBHEyBYSJSPK+/5Nw7KGnT1dIueEjgAz2BtIVM7gppvhZygsD5A
+        TrpMKw2OfGmNJ4EwxNcQtApBi5ujNsgDB4FrW+mkiRFrdCqtYZ9jkAc/sJ9iNw4VOIAyoAmdUSYD
+        6zp+8g+3tgrfJXoF8Cv70wMWpWY+6FrKJ6EvN2ZjxqzPePyHwHdOVQswCA6pdVfjcee9cjZzWBTs
+        djkew1IwCkb95hqXEcEHV8WhahKDVR1yayQXNJYFdKDRZBVmxJRfHQjkuJNQwdlqy+LtVcg5ri8p
+        VqmKwZbkUCDgTLHaTo4TSEhTe9LW3lflBFQ4+D276phft/LAtaPGIvThw7f5ci9Yl6FRn4mJJlzZ
+        4BTtJAWWomjR+QR7p9q0mUWsyU/Ax06VgQ9s9cHyNX/VZybUxD1titnDYVn6nuMbLAhuGEzbUlQV
+        ju8lEN/LxNaoylr2ARgCzmiWzZqcCyidSBSU0IlzdBizEkwGgz9K8Q65Jqjh9qA/cFVjapvr7N3t
+        6pngttKcAAn1nY1xW2mhvq2UTtiJE5cOEMKsGOraq1aDAuNcGeJqovG6Ua7ncEOpMqoR06awiW6O
+        7fxL086Hem2ihkw/tU138PRxWgWn7EmnTZlyu+e/zDdN2RNSZwtouyzUJXNnkG5AOgqv2xFpbJm1
+        iVDeYvLdybo8jsGaGWCy493B8vmGAA/o4AmHrE4F/K9gG7PODxti2F3SLlzInUp4fiXZLQUp4xJ4
+        Q0JApUXcul860rN8xx3nRFaQn21MNFiGT/3578lxhTqrSfZjYXmKOvenziGSIvn8N0Jvjbi9X9+t
+        ot6Ku+zWZkx1K1t4Op8tzp+/+HFx/tPPi4uL+eLli1EH3EBGlWdx3lJA6eN+lUccoCjD2t6T4fXY
+        LPnnLcbglXBiPl/MDw7BBtRf2brLg7j+hkS34cti8B7h5JHXdS0Zrl//uY4GAoUTWp1Ao4GOX5P8
+        n7A4x1O00aEwba1+5zZXbVEy4n2spuez+TTV6PMpPZRN2KjrkGUifm6rCJf/vn3zz93HxcXLVVV9
+        vv30ah6NnkZfAKxUTFiABwAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:33:51 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=2226
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Direct Part object"}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '75'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61YXW8bNxZ9z68g9BLbGCuO06ap3xx/tEbttTY2NumuFwg1Q0lcz5ADkmNZCfLf
+        99xLcmbkOOg+bBEUMoe8vJ/nnsuvL4SYlNJUupJB+cmR+BdWhPjK/6dv1gRlAj7kJSy20oVhb/zv
+        6+g3tgT1SIcm1/dyU4hahZdezJ2S96KyayPWKxmEFHeTU+1UGcQMEoWd/we/7ybCqYVyXgRbiMb6
+        IGp9r+qNWOuw0kaElRKs1iOOLCDl5PhU7JzYpu2CcvvHulKVOFVeL82u8HYR1tKpQpDSuuxq6SDK
+        GgU50KHzykPEQsnQObU/lx6HsVU2Kjhd4v5K1doshWxbZ2W5mt6ZO7O3d2KdEifWlKoNR3t7tHi8
+        bQ7s2PEWYnSDK0pZ15BMJt/YWld5i3XC66aFSvQpLu4KzTp1poIaJshazDtdV6TGvLblvYAXyOhs
+        3FRcBDitdcpjO5312FuT0auN17gbDmtaGG2iy4yQ3qtmXm+mQtzCqfe0rBGS4bBotSoVrbMVK7p9
+        Yzuxtl1diUaabiFLchrZ0HauXMF3yTt/qI04WcGLJSKiPfwOuaYS59HNPsZtHPtrjn3y5B4yaG/v
+        N2VTEE7VQhsdtDXYAH1VTIvSdaWGbdK3JOc7mfCihjeWvZyqlxPN9ljxpdNzaERZ5VeyVayo11/Y
+        dFqlxJnG7fgXNi05FAHrHY64prTMAUl+5EDPbbWZDlZlF5AlpCU2OsrnprEGQinQyMpWLJxtxF7K
+        S78HhY9zlsb0QKrCpME42yonybaY2LKqPEXGqcY+wL5GUihkPUXW0l1ZGIwyZd1V6oh0pNqNep49
+        BodV1vMEhRu4CLJNG4HqU6aKi4enAsWx0EgaWVteamVYiZ3Od+wqnAtO6uWKatmo3en4pg/qwdYP
+        8aYPNuSbxkKdRS1w2j5SCCxCD41U1mdL3O+2/k7rFdbgFohZroaYjk+da9Rn8K8+0E1JlS7ah6xw
+        rVDVUvmtI0jwhnBq6665elBU6N9vv0RuPO/NmHYcNXjJeM5QL3xjbVhRTqiwVgpxXVuKaEPQk1yz
+        fcUNtrU/jBjyIK48F6stOTMZkCxmW1LT1UG3OKaNDxLAl6q4T0pEJ1YYIyhLEDsUbukKUWrH2FsI
+        FcrpkwTQcx8LW5tCrJEx+4T4Q4Yi4EhnyiFllk90vVmpuubjCHxt16Sq7UI2nHqPTHYTTOiFhnp0
+        Bxyuy3ujvB9V5ywif44qYezGB9V4ahS5L8TelGzldKqA8YgbRY3Qw6maK9GvdOtz25IJSMQ5Yqge
+        JUAfAE2na7YqAbOiuiNRRZIcb4y+pjwuKAfok5OV7nIQOH0ZSsi0QVECLoAUfyHRqqFOio5jHYIY
+        KGrPdbu5KiVZDFA3y5Q1WSYMwhWyCxaYkrCwa4k/9KX1skddNH/yCNqNBVYTVOaojrz+O1qEdZtX
+        CRvFrVOK/H9FKL/dmschuUe2k1Pi6QzXfdZ0tH/AiidQnk9p8iCgDJ72bS031KQ9N+Oc2HCaip36
+        bsIOyitPQP8lQSn8g7ao0iW0EeVt17G/WFfBfZrojy5Xg6ZrRS2A1ayiv6jRlpQNlQ7DvoqbG9zN
+        zYEk0gXprkbeE5gHFCpkK3QH3AXzobJebFL6ofweYKumZg99iRXU6nEUiqvUJsTMUUMJetypSKOV
+        fFB9MyEoSbsoxGBc0eVQrSmEJ0UkNVnCNGTCn4DUJa6FSl3d+ULMrEZiGCxx6+KUdw3TFVN1ZdAP
+        fI48UtrauldgYYATQp/cwfEPJYwuTOosIp3qUvmJnfOz40KcnJ/usgz6vFSG+yTldFl2jlJjjoTm
+        Qsp24eT76yu/O3LMiUX0tKHtN5x/5JYzEEL2K9wSyQaR23LYGlO1SAHXQ1KOwKO1EfFZRes0MT7+
+        Gwr1oedv5J1Rx0ejIXo4rqTjROuImhJBJiVHNKNSKUbIQQ185HsKkI5AmmgnCOPJCUTooBdTDWg7
+        V1FxgrEt7vhxpTKyMd0yHtnAGwmzh60FO+eHlkYKZJgkkHoRQJFokBKt5pEjscuzCJ7E+Zl/g2Ps
+        JuZ4yYOGl5tIVQnhttiC5oNURcA16keJUBNGP8cTSqJ3ju99PeU0yKLeA44ynyUv/9lTY3RHeAMN
+        t+ybcIL1ik3ju2skMI68rHImjHoLNb+jocddcns4Eq8PDkTTDOsfdUXLP2+v/q6IZh2Jw7h8Zw5Z
+        7+OKhg/iRmOl/wa1CnIV9JC8gz2Qsu5/1vA0NSnScUuZWQ74zidU/+6RECfsUPjBRvAc3EG6vplu
+        YdAxQwrl+LaHI9RA21yvA9bcTY7rrtGmawogdISizPbuDI0O48EpyQuUxYzdZpvZE0fwMbupKZg0
+        osZ04WaTOcdRrsHjUYH2cvp6pjOjjKM/yePTfLZGV9qq+50RH6Cdu2nrQFTGvZWFKjn0FhAwzh4g
+        EGULZHB6FD2vKPqizJKvvsf2VHcXJo1p+9dcu7gQXWIJRRrK8p3r61muw4vvxvQnnbJEIy1+/AIQ
+        45Lm/jnNZD3tjITnM+3/LMoa1osd4DoXt6aKjmsG9hUsQXzmiZsPFOLze8xjn3dT04x7423KlLL1
+        1DsiiWL6JYNktKIJ2GKiYmSKEJ47qhzGSKTmHNNW/0bAg9Z1HswiFXxm7PVbc29m3IzdIyJv1Dqm
+        Ind/XCgDP0ekeQ1MIR+64pZPp8iGgYnlrGIKOSpn9mgqkijtFL0li/ughsmhvz7wEA4yNB0aZEtX
+        vppJ3yty2rU1GGIYTvfbr1jmqzzwMd3OZPOvuuJTUdo57EhCBoc1vK6IO7SbZ87d8GDw6tLKKit8
+        I8eWcpDjqAQl6riPKNZc8iNMgpf+GabvwoCRzZcscwZKaF0TGwE+0ItTQr+YQBm7QKVLpi58iRcY
+        iztKYt8xp6QuKTl0sSuRRSg+okhDFjwSsc8393/1l5FJD9Jpi8GBDSPNZPCDEje3Z7NCXPx2dlPg
+        92Wc14ZXnVuwTLmWm3HKHj99dRnen+LwOTw+8RxECDzOnQvq2XlyRN8cPdpsJe2QsZESPsNCk8Tz
+        v3zO0z4BFJdoftzryUIMFj9z6TbHJHMQuuE2OzR1BMISGOigDWSA8bP4rV5j3RLSvqg8I/bPdQw0
+        zMzY0ReLnv7HiXWT6OOWNNoSO5i7J+UYWnbUdDlF3MjrH/EBjkI9gFcfY1rD8UKccy8Rb94e4DeG
+        ByzuItx825IYF8nlGYGfGdLIXCJwMVPo7ezOTEaPvd/63/8uhidih15F77/s8Lz9W94woXc4v/qA
+        KcUa2nZzez2b9F/lw/LSLhGSOb0y7x9Mfzp4++vbw18O3r39+e27N4dvDl/km/nOSeflUl2pIAmv
+        +7fqCSQ0bbi198qcYPSgB+k38ZLRm/fW59eH796lHQHIVD/5+Ovr4jvJ/hT36nr8Hj56Kof9skaF
+        kpG3Z59uJyMfhS3Fso9ejFz5VM3/011k5fZ1L1JwYrz+gRLTMTBLBeDS+4fTg/0FeuVqXz22LHeC
+        7EVRe3VR0b5wqZX8Y/bp8p831jwsZ+9+2bTv/n4xefHtxX8BIWWHV2QYAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:34:05 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=8641
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_part_dict_without_parts_wrapper.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_part_dict_without_parts_wrapper.yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Test content without parts wrapper"}],
+      "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '91'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61SwW7bMAy9+ysInZPAdZfM2aWHbRg6dGjWBu2AdhjYiLGFKJIh0WmDIP9eOq5T
+        Z7vOMAyZ74mPek+7BEAt0GmjkSmqT/AgFYDd4dtg3jE5FqArSbHCwO/c9tn11kJhemk2qesVbgdw
+        CbXTFCKL0kj+no21EChW3mnQJtCC7VaqXPqaoQokmtq4Arg0EeRtFMEvAcFiKCiA9ot6LYOBD8AY
+        VyOA+xJZ6rD1NTgiffHoVG+o/XH9e/B+lOAtNXOuvSbb0fcdQS2NM7G8IYzeNbTb+fVMHVHcFFe+
+        qIJ/atwYpqPJx2ycTtLxdHo2TfMP+TjplA+aqo5Y0A9iFLfx6KmSDuuK535F7rOvD26PW5FeNidw
+        lr/h7BntCXR+Pvina/wimsb2M+vFKWdHa3jbHHD+9ddc9fzhk6E6f5KejX+P+J+0svxULHmLpU3q
+        Ti6TaSMpaC0hDbNROlxajOWQXqpDV9VesEiXuuGFfEL4ne6vNuHJbYrZn9m3ZfbzWSX75BX3+cVf
+        BgMAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 06:07:44 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=765
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_part_instance.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_part_instance.yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Explain quantum computing in simple
+      terms"}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '98'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61WTW8bNxC9+1dMdGmykA3n2/al8FcbI7WdxEIboO6B2h1pWXHJDcm1rAT5733D
+        3ZVWsVGgQH0wtORwZt6bN0N+2yEa5coWulCRw+iI/sQK0bf0X/acjWwjNvolLNbKx41t+/dt8Bsm
+        ke/l0Oh6oVZjMhx/CjT1rBZUuKWlL42ysakod1XdRG3npC0FXdWGKbKvwh5dVGquLZMiz/PGKN8Z
+        s6epjmT0QvaMnpeRwlLHvDwirAMMTZlYxxKWWeYsPX3+LMvIpa/ZjJ7u43OPaFIqyUrHvVt7a6/c
+        ckx6HbNPEKHG8GkMF1jNsi8NVtLxCxsiq4LcjP5uQkRQgYFwCIQw4+Rkus7oSIJkoCbLrruU1t99
+        UusFTyfXk3fi7PjqTLzR8YQm787p5vjynCYXl+dPxPrWTkod6HY0dbEkFQmYKagKHOqKb0f4TtSG
+        HkGWhaZmX7ugo3ZWcMCDXQiIDae5k2LU2tquMOJWaY+aCGHWRSqBPACiLXCuW4tKG6yl70wyylqz
+        ZJU2qbFRmxQJayHxnmU3bkzLthYSaKrnVLAyP7cITzhXTeCWy9CXF0lVjYla9BKiSFfgO5vzeFC8
+        tWDkFN/XxnmmStkVgYGgp9qABhyF8OBMWXZNMKttTqIwvFSrQf0+dXo87dwfQV008eLJQTzBmUbY
+        lYxUqsSY5k6ojKV3zbwkVnlJrk5GifO85HwhFnzHfkULXkntlfzISwWwLXEr19BMC5vgySflI+Be
+        n9fHDvYjeaH8rTi63AZ0aegY5wzCWreUJJalRn6SRGONyxdtXQrnfFexY5Rbuus9TE7FSx2P6NzC
+        zdxwhXHRlq7vYEm7VHdQ5dIJq67xkBfnWpmNzER06Pos2/ZDFSsrCbTqhhCSISlU0qBKELUWpqb6
+        q/JYQ6Ug01mKaZxbtDjbU0mIgbn11qkQDkB1p2c5la0JyRIj69jUgk6eNic71aNwlvRM7FYpuUob
+        4V1G5RMh4+MPmkQzAAwPwFJ02LWW89irXRJGv86cbw8avpdWziG/topVg0rNVBCRI0/7YFb2TXZh
+        6aapKuVXR21xtqW8nVWKnWALkm6U7stge763mVKPI+oyT6e7Zt0f0/OxnH50TNHTrZn07F8j/KdG
+        HsNk0fYdV7CUiwyag9KHtIFcytlHabOowiIMEhhqMcktrPG5OQstqLxVUyNRardEqRqzVaG9ju3s
+        DxhDnhqNuOTElI7diHsIU2gPUWzb6as9ZoZH4lDmnCG3aRNbqZXOFEgBAgHkDUZBNZhYZ77BUNUh
+        dzJfZC7cCFMq3byVM4x8WUBh8gY9t2R5SQUOhfVwucSQ9fAMknPN6HnxcoobPfkQ+3QZVLVHjALM
+        d+ZrB79oq2zq+coVLIyl+XSGzjGubhMBbJXnjcdhGXSdPbDgEghx4+vUr2pUwKu6TGhO5GWR5ue9
+        DikhZCg2aQwjr3yQ6BhjLT1FUDcZDIC8dnzso57pFPUCDx+D50WP9TjP2bDvOMMEl9FmUBYZX32X
+        VbXzMjzoCpUIg1Z7vMZybXZXg0Pr1kblaVx61LXizf0FpadWCc5ZuZ66GdMNUf01EZ4yCknPUeWL
+        pMl0nSQzoKK4quWOmhGKBOxVj/uk0aYQ8zRvvBBbVfL940Ua5C2hQS0Xego5FnoGv2i5hP+dqxn6
+        l8ZLt+Zc3yGczFTVve2E+gJuQFGR2Bc93mmIB0k9eBNibo4Gr8rv699/jTdvUQ/1ykMziao3/94b
+        jKAiHcpPrIKzYnYzuf4wWu+qu/lvbi5syHN2d3/v5YvXLw8OXr05OHx7ePj29auDnT5yijlqAvrv
+        kqPCc1mtH8UjeKjqOHELtqeuSc/lN22QweN6a/v1QW8QXVRme+/wxfiB33DG6aoZPLsHL3Kghw7i
+        SiBOzj9PRgOG4lZaPUM7AyJ/TPJ/igWM29F2usq0xfodQtBtVeYMuendF3v7uzOjQrmLGZ/cjjyH
+        GmOULwqxuwvXrN7/enDCX4y9m3/Q/PnKfXw12vm+8w8HrXFkygwAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 05:21:06 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=4449
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_pydantic_config_and_content.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_pydantic_config_and_content.yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What is 1+1?"}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "You are a helpful assistant"}], "role": "user"}, "generationConfig":
+      {"temperature": 0.7, "topP": 0.9, "topK": 40.0, "maxOutputTokens": 100, "stopSequences":
+      ["END"], "presencePenalty": 0.1, "frequencyPenalty": 0.2}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '328'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61RXU+DMBR9769o+upYoMBcTHwwaoxfcdmI0agPddwBCi2hnZkh/HdbGKzoq31o
+        mntO77nn3BphTNaMx1nMFEhygl90BeO6vQ0muAKuNNCXdLFklTpwu1Nbb01RsDOfiIePsIdPMX3l
+        xGI0w/ttcuhbiRzMp0LEkPf0pieQTcYzmS6BScENbRU9LMiAsq/kTiRlJd7NaI4/9Wh4HAa+6wX+
+        jAZhAI4bol68lSVbyRK4B8W0ezZ4JLpJUapIfAI/F9vWvUc7ISusET7fw0oolo8Q6k7+dJUXWjPL
+        7QyteLV9lmfq23iMLp8iYkWkxkP1GSEryt8j/pPYfKyF9pvplvUIlcy6rSRQ6D05dOo6m5zJ1IFd
+        2TYlFchScAnXseHxagXsZhZdOcWygPWC3n6k8uyZoAb9AMYCvE6WAgAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:16:30 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=470
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_typeddict_config_and_content.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_typeddict_config_and_content.yaml
@@ -1,0 +1,63 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What is 1+1?"}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "You are a helpful assistant"}], "role": "user"}, "generationConfig":
+      {"temperature": 0.7, "topP": 0.9, "topK": 40.0, "maxOutputTokens": 100, "stopSequences":
+      ["END"], "presencePenalty": 0.1, "frequencyPenalty": 0.2}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '328'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61Ry26DMBC8+yssXxsiIIBopV76OETqI21QVamtKqdsCArYFJsoKOLfa0Mgpr3W
+        B8vaGe/szB4QxuSLsjiNqQRBLvCbqmB8aG+NcSaBSQX0JVUsaClP3O4cjLeiSNjrT8TBZ9jBl9h9
+        Z8RgNMP7Y3LqW/IM9Kecx5D19KYnkHXKUrF5Bio407Rl9LggA0p3yR1PipKv9GjW+TTwPDsIg5lr
+        e649832wbB/14q0sqQRN4B4kVe7p4JGoJnkhI74Fds2r1r3jdkJGWCM8PMKSS5qNENee/OkqbpRm
+        mpkZGvEq+zRLZa09RrevETEikuOh+oyQEeXvEf9JLBxroeNmumW9QCnSbisJ5GpPlju1rXVGxcaC
+        fdE2JSWIgjMB81jz2GoJdF5VD5/BN9sli5rXV9snQVCDfgBEu319lgIAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:16:30 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=412
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_webp_image.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_generate_with_webp_image.yaml
@@ -1,0 +1,64 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"inlineData": {"data": "_9j_4AAQSkZJRgABAQAAAQABAAD_2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL_2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL_wAARCAABAAEDASIAAhEBAxEB_8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL_8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4-Tl5ufo6erx8vP09fb3-Pn6_8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL_8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3-Pn6_9oADAMBAAIRAxEAPwDjKKKK-ZP3E__Z",
+      "mimeType": "image/jpeg"}}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '943'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/41T0W6bMBR95yssP0YBNWQpad6itVsrLUq1RtOkdQ8GX8CKsZltslZR/n02LgQy
+        dRoSyPI5Puf6nssxQAhnRFBGiQGNV+iH3UHo2H4dJoUBYSzQbdnNmihz5vrnOFhbioEXdwjfgwJE
+        7KtlBaiWWrOUA6KgM8Vqw6TQKJcKmRIQq0gBq2fxLCaTJ1bVlnc74K0mkxaz8msrxxlFCihKSbYv
+        lGwEjXrwV+MsZd4SMsml6jDhXVDOOLfYb2ZKR4q860aqgecBxpZe1Z9vDxLUCGarr84+rXBfSKpY
+        URpfJpfZ3pV0WY7rr4YpOrBUEeHJOQNOIzxo6alf/5yeg1CSg+tyJSnwjn7qCDhngunyKxAthaM9
+        7baPuEfJofgii1rJ1GUZXkXXs5tFEsfxPLmezT7Ey0XQObeeuNH25hswxM4K6ScCW4WqNju5B/HR
+        xuBijxc33mYwWyNCsnzDjTSEj6D5PJn+JaxvrS3jw6EbzKO9PuHMvLo7PmzWn+/woEdmXNjyskvv
+        6Ozuvu/elZl1IsEgkcu7/n/N//RKlmOz4K12H/o3UJr5dAuobN5hHF2FOSe6DOGlblWxAl3bHwge
+        qOMZ/Qpke7/5VEMmDsVjuE0WzVrj4BT8AVguJZAPBAAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 05:59:19 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=1367
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_multi_turn_with_function_response_typeddict.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_multi_turn_with_function_response_typeddict.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What''s the weather in Paris?"}], "role":
+      "user"}, {"parts": [{"functionCall": {"args": {"location": "Paris"}, "name":
+      "get_weather"}}], "role": "model"}, {"parts": [{"functionResponse": {"name":
+      "get_weather", "response": {"temperature": "15C", "conditions": "sunny"}}}],
+      "role": "user"}], "tools": [{"functionDeclarations": [{"description": "Get the
+      weather", "name": "get_weather", "parameters": {"properties": {"location": {"type":
+      "STRING"}}, "required": ["location"], "type": "OBJECT"}}]}], "generationConfig":
+      {}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '554'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61R0U6DMBR95yuaPo8FJjDim3E+aDQuG1ET9eE67qARWmyL27Ls3y0wtqKvNk3T
+        3HN6z+05e4cQugKeshQ0KnpJXk2FkH17NpjgGrk2QF8yxQqkPnO7tbfuhqJx2zyiSY5kg6BzlIRx
+        MgfJFDFb1ZzvyIbpnADRWFYoQdcSiVgTP7wev3FqNTyc7u+j8xhSFNholCLFoqcfegJdM85UvkBQ
+        gje0ZfI4pycUvrN7kVVSfDQ/cb2x53l+EEzDKPaiMIijOIgDpxdvZWmtIMMH1GDMgpMl1DQpK52I
+        T+TXom7Nuph0Qpa3A9yPjrgWGooBFMSjP23VzIiywvbcisP8Hwqmd63fNy8JtTzSw6l6kxzLy98z
+        /pOYHw3FnGM2XVxPKBXrcsmwNEm5k7HnrgtQuYvbqu1KJapKcIW3acPj0yXCfFFGX8/oXrl34WqS
+        zzLqHJwfDJ+nU8YCAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:16:31 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=495
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_structured_content_is_jsonified.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_structured_content_is_jsonified.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Reply with OK"}]}], "generationConfig":
+      {"maxOutputTokens": 5}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '98'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61R0U6DMBR95ytIn8eyFZiZb0Z9MNNtccQsUR+ucmFEaElblhnCv9vCYEVf7UPT
+        3HN6zz3n1o7rkk9gcRaDQkmu3Vddcd26vQ3GmUKmNNCXdLEEoS7c7tTWW1MUnswnslm9MWJBzfB+
+        n1waCp6jYRc8xrynNz2BJBnL5OEZQXJmaLtosyUDCsf0kael4B9mJs+fhssFnc+XM318GgYBerPQ
+        6cVbWVJJSPEJFWjbMJgjuklRqoh/IbvlVWvb73SskEYwPcOKK8hHSDj501PeacUst6OzUtXmIc/U
+        t3EY3e8jYgWkRiP1ATlWjr8H/CctOtZyzmvpNvWCQmbdSlIs9JI8Op15SQ7y4OGpbJsSgbLkTOJD
+        bHgodgjrarFOqpAd0+1VsKLpDSdO4/wAChLqBYwCAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:15:55 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=409
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_simple.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_simple.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Say hello back to me"}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '77'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/7VRS07DMBDd5xTG66ZKPwkNO0QrgRTUikYICVgYMk0tXDuKp6io6glYcQKu2CNg
+        JyR1gS1eWKN5b+bNvNl6hNBnJjOeMQRNz8i9yRCyrX6LKYkg0QBNyiQLVuKBW7+tExsKwsYW0UsQ
+        QhFcQgknZP/58f4gqcPctfFj59C/VAJs8UplIBr6riHQBZdcL2+AaSUtbZ5OZ7RF2WueqLwo1ZMd
+        0Q+6vdEwDAdRPDzth8EgigZeo1xp0rVmOVwDMmMBaxelpsOqwFS9gLxQ68qCsBZxDPsTRoVMHCG9
+        oPOrqR4bSS5cHx2LzepMcHyz+6WTu5Q69uCRaGOP57j4c8L/0fK+j1Lf6RZKzeuD5LAyJ/L73cBf
+        CKaXPmyKqiktQRdKarjKLG+czIElaTzRPI7i0QyTqVTnQ+rtvC9gf2exmQIAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:14:04 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=477
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_advanced_config.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_advanced_config.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Say hello"}], "role": "user"}], "generationConfig":
+      {"temperature": 0.9, "topP": 0.95, "topK": 40.0, "maxOutputTokens": 50, "stopSequences":
+      [".", "!"], "presencePenalty": 0.1, "frequencyPenalty": 0.2}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '237'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61R0U6DMBR971eQPo8F2HDOVzXROCM6YkyMMVXuoLG0pO3IDOHfbWGwoq/2oWnu
+        Ob3nnnMb5Hn4k/CMZkSDwhfeq6l4XtPdFhNcA9cGGEqmWBGpT9z+NM7bUDQc7Cd8A4wJ7GDt+H6b
+        nTpKwcDSS5EBG+jtQMA7yqkqnoAowS1tmz4keERJnW9EXknxYYfyw3kQxmer8Hy5juJgtV7EaBDu
+        JPFekRzuQRPjmYzOsGlQVjoVX8Avxb7zHPUaTkITODzCWmjCJshi9qenujKKlLm5OZEa44RR/W3d
+        pdcvKXbC0ZORhnCQk+HvAf9JK5xqoeNK+i09g1S0X0cOpVmQH80Df8eIKnw4VF1TLEFVgiu4zSyP
+        yi2QRNK7d7/mdZ7QZFMsHxVGLfoBzsTDfYkCAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:16:11 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=531
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_content_dict.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_content_dict.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What is 2+2?"}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '69'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61RXU+DMBR951c0fXUsBRljJr5MfTCZm3H4FTVLJ3eMDFpCOzND+O+2MFjRV/vQ
+        NPec3nPPuaWFEP6kLEoiKkHgC/SmKgiV9a0xziQwqYC2pIo5LeSJ25zSeCuKhIP+hF10hlx0ibx3
+        hg1G1b0/Bqe+BU9Bf8p4BGlLr1oC3iQsEdsHoIIzTVuGi3vcofQrnvE4L/haj2aTISHE8SaB5/rO
+        uU8mIzL2A6sVr2XxXtAY7kBS5Z52HrFqkuUy5DtgV3xfux83OkZWPTg4wpJLmvYQZzT401RcK8kk
+        NSM00lXuaZrIb20xvHkJsZGQ7M3UJmQZQf6e8J+0gr6WddxLs6onKETS7CSGTG3JdofE3qRUbG04
+        5HVTXIDIORNwG2nebrYEOn+cy9fFmsQrfwXP02mMrcr6AXxpxKyTAgAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:16:16 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=480
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_dict_config.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_dict_config.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Say hello"}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "You are a helpful assistant."}], "role": "user"}, "generationConfig":
+      {"temperature": 0.5, "topP": 0.9, "topK": 30.0, "maxOutputTokens": 50}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '250'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61RwU7DMAy99ytCznTKGFs3LggBYhMgCqsQEnAI1OsCWVw1KWxM+3eSdt1SzuQQ
+        WX7PfvbzOiCEvnOVipQb0PSEPNsMIevqdxgqA8pYoEnZZM4Ls+fWb+3FlmJg6YroGKTEAzLGb2Jl
+        yITMQeZkhSUxmPLV6YuiXuFmF78e7uUKlOB6LTAF2dA3DYHOhBJ6/gBco3K0aXIX0x3Kv7IbzPIC
+        39zEIeuwPhsNelG/dzzoDntRFAWNcqVJS80zuAXDrSN8tze1HRa5SfAT1DmWlSPDWsTzrwV32RY3
+        aLhsQ02p11VfWE0hfV89y+3uXAqzcgsml08J9fwxraEafwLPxr8j/pNWl7XFgu1Z6ks9QqFFfZIM
+        FvZI4VGHhTPJ9TyEZV51pQXoHJWGSep4H9EUeBzfX12r0WA0jFkofsozpMEm+AUV80RdqgIAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:16:15 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=465
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_function_call_response.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_function_call_response.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What''s the weather in Tokyo?"}], "role":
+      "user"}, {"parts": [{"functionCall": {"args": {"location": "Tokyo", "units":
+      "celsius"}, "name": "get_weather"}}], "role": "model"}, {"parts": [{"functionResponse":
+      {"name": "get_weather", "response": {"temperature": 22, "conditions": "sunny"}}}],
+      "role": "user"}], "tools": [{"functionDeclarations": [{"description": "Get the
+      weather for a location", "name": "get_weather", "parameters": {"properties":
+      {"location": {"type": "STRING"}, "units": {"type": "STRING"}}, "required": ["location"],
+      "type": "OBJECT"}}]}], "generationConfig": {}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '615'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61R0W6CMBR95ytu+ixGBAT3trglW+KimWRZsu2hyhW6QUvaMjXGf18BUdhe14em
+        uef0nnvPOVoAZEN5zGKqUZEbeDMVgGN9V5jgGrk2QFsyxYJKfeU259h5G4rGffWJRCnCDqlOUQLj
+        EImvgwCmQJWcH2DHdAoUNOYFSqpLiSC2MB5DjIlEVDDDTLFSDd856fQ/Xd4fg+tUUmRYSeYixqyl
+        n1oC2TLOVPqMVAle0VbRYkkuKP1O5iIppFhXi9mjoTOZhJ4fBCPPc50wGPlWq1xrklLRBJ9QU2Mc
+        vdhDTIe80GZN5DNR1sa5YaPS8bmHO8EZ10LTrAf5/uBPW3VnRFnW9b8TjVmeZkwfau/vXyPSMUj3
+        p2odsjpG/p7xn8ScoC9mnYNpsnpBqVgTSoK5ickeD0f2NqMqtXFf1F2JRFUIrvAxrnif6xXShes+
+        bNh0Mg2Xer7g4tYj1sn6AWvuKErTAgAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:16:13 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=464
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_pydantic_tool.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_pydantic_tool.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "The weather in Paris is 18 degrees celsius.
+      Summarize this."}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '116'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61Ry07DMBC85yssX7g0VYlSSrjxOlRQEWiEkIDDQrapwbGDvamKqv47TtK0CVzJ
+        wbJ2JjPrmY3HGH8HlYoUCC0/Y89uwtimPitMK0JFDmhHbliAoQO3+Tadu6MQrquf+JSOLAOWC5ky
+        Z8MKiWBBESPMCzRApUEmFIvBCDt8Ubwjs93fXwcHc6MlVsq5TlG29G1L4AuhhF0+OBetKto8uYv5
+        HoVVdquzwui3an9/NAwno/AkmoyDKJyEp1EYeq1z7clLCxnOkMDlA/sUuFPIC0r0J6pLXdb5HI8b
+        l06cfTzY4aQJZA8KJoM/svbKmQrZjbnTgHs8SEHf1QuT66eEdwKi/lZtQl4nyN87/pdZ0DfzdsU0
+        XT2isaIpJcPc1eQHw5G/kGCXPq6LWpUbtIVWFqdpxfswc4RZubr4urnPo2msbBDbc8u9rfcDZk2+
+        /LoCAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:16:14 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=637
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_system.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_system.yaml
@@ -1,0 +1,64 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What is the capital of France?"}], "role":
+      "user"}], "systemInstruction": {"parts": [{"text": "You are a helpful assistant
+      who speaks like a pirate."}], "role": "user"}, "generationConfig": {"temperature":
+      0.7, "maxOutputTokens": 100}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '270'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61RTU8CMRC9768YeuEChOVr0RsRTUw0rrIxBDVmgGG3cbdd20IghP9uCywserWH
+        ppn3Om/mva0HwGYo5nyOhjS7hjdbAdjub4dJYUgYCxQlW8xRmTP3cLalt6UYWrtPbJDIDZiEFNUg
+        sxKbCkQJwQxzbjAFWYU7hWJGMCUIUXFdA4QZNxsHpTxOjAYUVVAyczSLbqjyLlhJbXd6f9TOMyqZ
+        khsgk3NKC/quILAFF1wnL4RaCkcbRU8hO6G4ih9knCs5dWvWmw2/1/Z9v93vdYJu0L7qBV6hvNdk
+        S40xPZJBayOezGK2Q5abSH6RuJHLvY1+/6BScv0CbwVH3Ehr0AXU6db+tNVDK8rTchqloOzymFoz
+        3YbR7ThiJYPM5VSFQ17JyN8z/pNYK7gU847BHLJ6JaX5IZSYMhtTvdVo1hcp6qRO63zflSnSuRSa
+        7ueO96xGhOFnOJy0SazisD8Zp98Dzbyd9wNoCHVT4QIAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:14:58 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=681
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_tools.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_tools.yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What''s the weather in Tokyo today?"}],
+      "role": "user"}], "tools": [{"functionDeclarations": [{"description": "Get the
+      weather for a location", "name": "get_weather", "parameters": {"properties":
+      {"location": {"description": "City and country", "type": "STRING"}, "units":
+      {"description": "Temperature units", "enum": ["celsius", "fahrenheit"], "type":
+      "STRING"}}, "required": ["location", "units"], "type": "OBJECT"}}]}], "generationConfig":
+      {}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '480'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61STU/CQBC991c0e6ZkaSsFbwQ9SDCgEDUxxoztUDZud5vuViWE/+72C1rUmz00
+        7bw3897O271l2yQEEbEINCpyaT+bim3vy3eBSaFRaAM0JVNMIdMnbvXsW9+GsslFqJkUU+C801zj
+        AhI0dRKjfv1E0FvMSO+cBFmsfmk2SC5Y6YCEyBXL1Y9ew+EyhMJCQVvL953s2TNIQZAz6sH66+/0
+        /XKaTzLJS+uJjJA3ww4NgWyYYGp7j6Aq6dV6sTzaI/ARz2WcZvKtsO/QPqXU9dzApzRwLzzPH43c
+        wGrES1mSK4jxFjWYjOC4D2KGJKk2J0MxlXmZkedXQq1IO/iA1riWGngH8pvW1lh1ZUQZb0fdugXm
+        /MCZ3pX7vX5atzIw8zuumiVZrV2ee/wnsQHtill1NlVcD5ip+krEmJikHLdPnQ0HtXXwKy2nkgxV
+        KoXCm6jg3QUrhNnwcRKy8XA8Wur5QsiJT6yD9Q3EKf5dPgMAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:14:59 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=561
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_typeddict_tool.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_content_with_typeddict_tool.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "The weather in London is 65 degrees
+      fahrenheit. Summarize this."}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '120'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/7VRy07DMBC85ytWPpOqaUSScuMpIbWiohVCPA5Ls01cHDuy3VJU9d9xEtKmwBUf
+        LGtnvLM7s/UA2BxlylO0ZNgZPLsKwLa+K0xJS9I6oC25YonaHrjN2XbejmJpU31is5zgg9DmpIFL
+        GCmZKgncQMFFCk4YSkFoUFpAC9EppJRpIgM3mGuSOXHbe5Gs03y3f7+eHEbSSlClV6iUREvftQS2
+        4JKb/N4pKVnRprO7CdujuM5GKiu1equ28vu9IIqDMAyGcZAkYRyHidcq15psZTCjMVl0ruHeG+Y6
+        FKWdqXeSl2pVuxZEjUrH5L9xqyyKIygcnPxqa66cKBdd8zu5uOVRcPtZG3/9OGMdg+yxauuQ1zHy
+        54z/JOZ9B9Nk9UDa8CaUjAoXkz/o9f2FQJP7tCnrrkyTKZU0dJtWvKWeEo6X4fhpfRENk4lOBiY5
+        nzNv530ByEsRWtACAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:16:15 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=453
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_with_no_contents.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_generate_with_no_contents.yaml
@@ -1,0 +1,59 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": ""}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '57'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/52RwUvDMBTG7/0rHj3PuIMnTxYsUtzGUCeISHk0byHYJiXJCnP0fzdJ4+g87pS8
+        L1++/N7LKQPIyRht8ns4+cKXjebkq7vlcjEJHVmLImh5sa3gm46gtIMBW8kZbFtCS9CjtYCTCMnG
+        8pRgHbqDDQHV5r1YVY918fK0W5ebtz8HJ4eyDZbPKECiiYcP7tjH58PKhNbCv9lLyxrd3U4lM33D
+        ytBIpfY6pcbLxuNpleDr5/KjTgxzE9cdymi6TJ97Oo/I0eF5Ukm3ZAbZRD5Bigw6OVCLShz80P7R
+        5ueLY9qNi+v7XenGj/uH+Dr90Iy2DWcxhNTN7vWykav/M5vDf2VhN2a/7rke3kUCAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:15:04 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=139
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_multi_turn_conversation.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/google/cassettes/test_sync_multi_turn_conversation.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "What''s 2+2?"}], "role": "user"}, {"parts":
+      [{"text": "2 + 2 = 4"}], "role": "model"}, {"parts": [{"text": "And what''s
+      3+3?"}], "role": "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '179'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+      x-goog-api-client:
+      - google-genai-sdk/1.30.0 gl-python/3.10.15
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/61Ry26DMBC88xWWrw0R4Dwr9dT2EClRSYOqSG0PbtmAVbARdlAqlH+vDYGY9lof
+        LGtnvLMzWzsI4U/KYxZTBRLfolddQahuboMJroArDXQlXSxoqa7c9tTWW1MUnMwnTNANIugOzd44
+        thjn/v0+uvYtRQbmUy5iyDr6uSPgA+NMps9ApeCGtoueQtyjtErWIilK8WFGc/0xmZKlT3yPBMQL
+        lvMZuN7U6cQbWXyUNIENKKrd094j1k3yQkXiC/i9ODbug0krZIU1wBcXWAlFswFCgtGfrvJBa7LM
+        ztCKV9unGVPfxmP0uI+wFZEaDtVl5FhR/h7xn8QWQy3nspl2WS9QStZuJYFc78kNxp57yKhMXTgV
+        TVNcgiwEl7CKDW873wFdRftN5Va8SkIWrtPJVmLn7PwAReV7f5YCAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 15 Aug 2025 04:15:00 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=417
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/google/test_instrument.py
+++ b/sdks/python/tests/lilypad/_internal/otel/google/test_instrument.py
@@ -1,0 +1,1612 @@
+"""Tests for Google GenAI instrumentation."""
+
+import os
+import base64
+import inspect
+from io import BytesIO
+from typing import TypedDict
+from unittest.mock import Mock, patch
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+from PIL import Image
+from wrapt import FunctionWrapper
+from dotenv import load_dotenv
+from pydantic import BaseModel
+from google import genai
+from google.genai.errors import ClientError, ServerError
+from google.genai.models import Models, AsyncModels
+from google.genai.types import (
+    GenerateContentResponse,
+    GenerateContentConfig,
+    Tool,
+    FunctionDeclaration,
+    Part,
+    Content,
+    Blob,
+    GenerateContentConfigDict,
+    ContentDict,
+    PartDict,
+    Schema,
+    Type,
+    FunctionCallDict,
+    FunctionResponseDict,
+    ToolDict,
+    FunctionDeclarationDict,
+    SchemaDict,
+    BlobDict,
+    ContentListUnionDict,
+)
+from inline_snapshot import snapshot
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from lilypad._internal.otel.google.instrument import instrument_google
+
+from ..test_utils import extract_span_data
+
+
+@pytest.fixture
+def google_api_key() -> str:
+    """Get Google API key from environment or return dummy key."""
+    load_dotenv()
+    return os.getenv("GOOGLE_API_KEY", "test-api-key")
+
+
+@pytest.fixture
+def client(google_api_key: str) -> Models:
+    """Create an instrumented Google GenAI models client."""
+    os.environ["GOOGLE_API_KEY"] = google_api_key
+    client = genai.Client(api_key=google_api_key)
+    models = client.models
+    instrument_google(models)
+    return models
+
+
+@pytest.fixture
+def async_client(google_api_key: str) -> AsyncModels:
+    """Create an instrumented Google GenAI async models client."""
+    os.environ["GOOGLE_API_KEY"] = google_api_key
+    client = genai.Client(api_key=google_api_key)
+    models = client.aio.models
+    instrument_google(models)
+    return models
+
+
+@pytest.mark.vcr()
+def test_sync_generate_content_simple(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test basic content generation with span verification."""
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents="Say hello back to me",
+    )
+
+    assert isinstance(response, GenerateContentResponse)
+    assert response.text
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "DLSeaLT9Esi9698PtLOnoA4",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 5,
+                "gen_ai.usage.output_tokens": 5,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "Say hello back to me",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "content": "Hello there! \\ud83d\\udc4b\\n"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_async_generate_content_simple(
+    async_client: AsyncModels, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test async content generation with span verification."""
+    response = await async_client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents="Say hello back to me",
+    )
+
+    assert isinstance(response, GenerateContentResponse)
+    assert response.text
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "QbSeaMDQJP-vnvgPiPLh4Qs",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 5,
+                "gen_ai.usage.output_tokens": 3,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "Say hello back to me",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "content": "Hello!\\n"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_generate_content_with_system(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test content generation with system instruction and span verification."""
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents="What is the capital of France?",
+        config=GenerateContentConfig(
+            system_instruction="You are a helpful assistant who speaks like a pirate.",
+            temperature=0.7,
+            max_output_tokens=100,
+        ),
+    )
+
+    assert isinstance(response, GenerateContentResponse)
+    assert response.text
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.request.temperature": 0.7,
+                "gen_ai.request.max_tokens": 100,
+                "gen_ai.system": "google_genai",
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "QrSeaP_PDZ3envgP8ZXlqAs",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 18,
+                "gen_ai.usage.output_tokens": 27,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.system.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "You are a helpful assistant who speaks like a pirate.",
+                    },
+                },
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "What is the capital of France?",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "content": "Ahoy there, matey! The capital o\' France be Paris, a city o\' lights an\' romance, aye!\\n"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_generate_content_with_tools(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test content generation with tools and span verification."""
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents="What's the weather in Tokyo today?",
+        config=GenerateContentConfig(
+            tools=[
+                Tool(
+                    function_declarations=[
+                        FunctionDeclaration(
+                            name="get_weather",
+                            description="Get the weather for a location",
+                            parameters=Schema(
+                                type=Type.OBJECT,
+                                properties={
+                                    "location": Schema(
+                                        type=Type.STRING, description="City and country"
+                                    ),
+                                    "units": Schema(
+                                        type=Type.STRING,
+                                        enum=["celsius", "fahrenheit"],
+                                        description="Temperature units",
+                                    ),
+                                },
+                                required=["location", "units"],
+                            ),
+                        )
+                    ]
+                )
+            ]
+        ),
+    )
+
+    assert isinstance(response, GenerateContentResponse)
+    if response.candidates:
+        first_candidate = response.candidates[0]
+        if first_candidate.content and first_candidate.content.parts:
+            assert any(
+                hasattr(part, "function_call") for part in first_candidate.content.parts
+            )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "gen_ai.request.functions": ("get_weather",),
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "Q7SeaJ6WAci9698PtLOnoA4",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 34,
+                "gen_ai.usage.output_tokens": 10,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "What's the weather in Tokyo today?",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "tool_calls": [{"id": "tool_0", "type": "function", "function": {"name": "get_weather", "arguments": "{\\"units\\": \\"celsius\\", \\"location\\": \\"Tokyo, Japan\\"}"}}]}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_multi_turn_conversation(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test multi-turn conversation with span verification."""
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=[
+            {"role": "user", "parts": [{"text": "What's 2+2?"}]},
+            {"role": "model", "parts": [{"text": "2 + 2 = 4"}]},
+            {"role": "user", "parts": [{"text": "And what's 3+3?"}]},
+        ],
+    )
+
+    assert isinstance(response, GenerateContentResponse)
+    assert response.text
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "Q7SeaITXMv-vnvgPiPLh4Qs",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 24,
+                "gen_ai.usage.output_tokens": 8,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "What's 2+2?",
+                    },
+                },
+                {
+                    "name": "gen_ai.model.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "2 + 2 = 4",
+                    },
+                },
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "And what's 3+3?",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "content": "3 + 3 = 6\\n"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+def test_preserves_method_signatures() -> None:
+    """Test that instrumentation preserves original method signatures."""
+    os.environ["GOOGLE_API_KEY"] = "test"
+    fresh_client = genai.Client()
+    fresh_models = fresh_client.models
+    original_generate_sig = inspect.signature(fresh_models.generate_content)
+
+    instrumented_client = genai.Client()
+    instrumented_models = instrumented_client.models
+    instrument_google(instrumented_models)
+
+    assert (
+        inspect.signature(instrumented_models.generate_content) == original_generate_sig
+    )
+
+
+def test_multiple_clients_independent() -> None:
+    """Test that multiple clients can be instrumented independently."""
+    os.environ["GOOGLE_API_KEY"] = "test"
+    client1 = genai.Client()
+    models1 = client1.models
+    client2 = genai.Client()
+    models2 = client2.models
+
+    assert not isinstance(models1.generate_content, FunctionWrapper)
+    assert not isinstance(models2.generate_content, FunctionWrapper)
+
+    instrument_google(models1)
+
+    assert isinstance(models1.generate_content, FunctionWrapper)
+
+    assert not isinstance(models2.generate_content, FunctionWrapper)
+
+
+@pytest.mark.vcr()
+def test_error_handling(client: Models, span_exporter: InMemorySpanExporter) -> None:
+    """Test error handling and span error recording."""
+    with pytest.raises(ClientError):
+        client.generate_content(
+            model="invalid-model-name",
+            contents="Hello",
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat invalid-model-name",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "invalid-model-name",
+                "gen_ai.system": "google_genai",
+                "error.type": "ClientError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "400 INVALID_ARGUMENT. {'error': {'code': 400, 'message': 'API key not valid. Please pass a valid API key.', 'status': 'INVALID_ARGUMENT', 'details': [{'@type': 'type.googleapis.com/google.rpc.ErrorInfo', 'reason': 'API_KEY_INVALID', 'domain': 'googleapis.com', 'metadata': {'service': 'generativelanguage.googleapis.com'}}, {'@type': 'type.googleapis.com/google.rpc.LocalizedMessage', 'locale': 'en-US', 'message': 'API key not valid. Please pass a valid API key.'}]}}",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+def test_client_marked_as_instrumented() -> None:
+    """Test that client is marked as instrumented after instrumentation."""
+    os.environ["GOOGLE_API_KEY"] = "test"
+    client = genai.Client()
+    models = client.models
+
+    assert not hasattr(models, "_lilypad_instrumented")
+
+    instrument_google(models)
+
+    assert hasattr(models, "_lilypad_instrumented")
+    assert models._lilypad_instrumented is True  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_instrumentation_idempotent() -> None:
+    """Test that instrumentation is truly idempotent."""
+    os.environ["GOOGLE_API_KEY"] = "test"
+    client = genai.Client()
+    models = client.models
+
+    instrument_google(models)
+    first_generate = models.generate_content
+
+    instrument_google(models)
+    second_generate = models.generate_content
+
+    assert second_generate is first_generate
+
+
+def test_async_instrumentation_idempotent() -> None:
+    """Test that async instrumentation is truly idempotent."""
+    os.environ["GOOGLE_API_KEY"] = "test"
+    client = genai.Client()
+    models = client.aio.models
+
+    instrument_google(models)
+    first_generate = models.generate_content
+
+    instrument_google(models)
+    second_generate = models.generate_content
+
+    assert second_generate is first_generate
+
+
+def test_preserves_async_nature() -> None:
+    """Test that async methods remain async after patching."""
+    os.environ["GOOGLE_API_KEY"] = "test"
+    client = genai.Client()
+    models = client.aio.models
+
+    generate_result_before = models.generate_content(model="test", contents="test")
+    assert inspect.iscoroutine(generate_result_before)
+    generate_result_before.close()
+
+    instrument_google(models)
+
+    generate_result_after = models.generate_content(model="test", contents="test")
+    assert inspect.iscoroutine(generate_result_after)
+    generate_result_after.close()
+
+
+def test_sync_generate_content_client_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test sync generation with ClientError."""
+    mock_models = Mock(spec=Models)
+
+    original_generate = Mock(
+        side_effect=ClientError(
+            code=400,
+            response_json={
+                "error": {"message": "Invalid request", "status": "INVALID_ARGUMENT"}
+            },
+        )
+    )
+    mock_models.generate_content = original_generate
+
+    instrument_google(mock_models)
+
+    with pytest.raises(ClientError):
+        mock_models.generate_content(
+            model="gemini-2.0-flash-exp",
+            contents="Hello",
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "error.type": "ClientError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "400 INVALID_ARGUMENT. {'error': {'message': 'Invalid request', 'status': 'INVALID_ARGUMENT'}}",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_generate_content_server_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test async generation with ServerError."""
+    mock_models = Mock(spec=AsyncModels)
+
+    async def generate_error(*args, **kwargs):
+        raise ServerError(
+            code=500,
+            response_json={
+                "error": {"message": "Internal server error", "status": "INTERNAL"}
+            },
+        )
+
+    original_generate = Mock(side_effect=generate_error)
+    mock_models.generate_content = original_generate
+
+    instrument_google(mock_models)
+
+    with pytest.raises(ServerError):
+        await mock_models.generate_content(
+            model="gemini-2.0-flash-exp",
+            contents="Hello",
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "error.type": "ServerError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "500 INTERNAL. {'error': {'message': 'Internal server error', 'status': 'INTERNAL'}}",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_wrapping_failure_generate(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test async client when wrapping generate_content method fails."""
+    mock_models = Mock(spec=AsyncModels)
+    type(mock_models).generate_content = property(lambda self: Mock())
+
+    with caplog.at_level("WARNING"):
+        instrument_google(mock_models)
+
+    assert hasattr(mock_models, "_lilypad_instrumented")
+    assert mock_models._lilypad_instrumented is True
+    assert "Failed to wrap generate_content: AttributeError" in caplog.text
+
+
+@pytest.mark.vcr()
+def test_structured_content_is_jsonified(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test that structured content is properly JSON serialized."""
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents={
+            "parts": [
+                {"text": "Reply with OK"},
+            ]
+        },
+        config=GenerateContentConfig(max_output_tokens=5),
+    )
+    assert isinstance(response, GenerateContentResponse)
+
+    spans = span_exporter.get_finished_spans()
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.request.max_tokens": 5,
+                "gen_ai.system": "google_genai",
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "erSeaNu6Nfu5nvgP74K2gAo",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 3,
+                "gen_ai.usage.output_tokens": 2,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "Reply with OK",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "content": "OK\\n"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+def test_package_not_found_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test handling of PackageNotFoundError when determining lilypad-sdk version."""
+    with patch(
+        "lilypad._internal.otel.google.instrument.version",
+        side_effect=PackageNotFoundError("Package lilypad-sdk not found"),
+    ):
+        mock_models = Mock(spec=Models)
+
+        with caplog.at_level("DEBUG"):
+            instrument_google(mock_models)
+
+        assert hasattr(mock_models, "_lilypad_instrumented")
+        assert mock_models._lilypad_instrumented is True
+        assert "Could not determine lilypad-sdk version" in caplog.text
+        assert isinstance(mock_models.generate_content, FunctionWrapper)
+
+
+def test_sync_generate_content_api_connection_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test sync generation with connection error."""
+    mock_models = Mock(spec=Models)
+
+    original_generate = Mock(
+        side_effect=ClientError(
+            code=503,
+            response_json={
+                "error": {"message": "Connection failed", "status": "UNAVAILABLE"}
+            },
+        )
+    )
+    mock_models.generate_content = original_generate
+
+    instrument_google(mock_models)
+
+    with pytest.raises(ClientError):
+        mock_models.generate_content(
+            model="gemini-2.0-flash-exp",
+            contents="Hello",
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "error.type": "ClientError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "503 UNAVAILABLE. {'error': {'message': 'Connection failed', 'status': 'UNAVAILABLE'}}",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+def test_sync_generate_content_rate_limit_error(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test sync generation with rate limit error."""
+    mock_models = Mock(spec=Models)
+
+    original_generate = Mock(
+        side_effect=ClientError(
+            code=429,
+            response_json={
+                "error": {
+                    "message": "Rate limit exceeded",
+                    "status": "RESOURCE_EXHAUSTED",
+                }
+            },
+        )
+    )
+    mock_models.generate_content = original_generate
+
+    instrument_google(mock_models)
+
+    with pytest.raises(ClientError):
+        mock_models.generate_content(
+            model="gemini-2.0-flash-exp",
+            contents="Hello",
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "error.type": "ClientError",
+            },
+            "status": {
+                "status_code": "ERROR",
+                "description": "429 RESOURCE_EXHAUSTED. {'error': {'message': 'Rate limit exceeded', 'status': 'RESOURCE_EXHAUSTED'}}",
+            },
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "Hello",
+                    },
+                }
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_generate_content_with_advanced_config(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test generation with advanced configuration parameters."""
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents="Say hello",
+        config=GenerateContentConfig(
+            temperature=0.9,
+            top_p=0.95,
+            top_k=40,
+            max_output_tokens=50,
+            stop_sequences=[".", "!"],
+            presence_penalty=0.1,
+            frequency_penalty=0.2,
+        ),
+    )
+
+    assert isinstance(response, GenerateContentResponse)
+    assert response.text
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.request.temperature": 0.9,
+                "gen_ai.request.top_p": 0.95,
+                "gen_ai.request.top_k": 40.0,
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.request.stop_sequences": (".", "!"),
+                "gen_ai.request.presence_penalty": 0.1,
+                "gen_ai.request.frequency_penalty": 0.2,
+                "gen_ai.system": "google_genai",
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "irSeaPriK_-vnvgPiPLh4Qs",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 2,
+                "gen_ai.usage.output_tokens": 1,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "Say hello",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "content": "Hello"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_generate_content_with_function_call_response(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test content generation with tool response handling."""
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=[
+            {"role": "user", "parts": [{"text": "What's the weather in Tokyo?"}]},
+            {
+                "role": "model",
+                "parts": [
+                    {
+                        "function_call": {
+                            "name": "get_weather",
+                            "args": {"location": "Tokyo", "units": "celsius"},
+                        }
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "parts": [
+                    {
+                        "function_response": {
+                            "name": "get_weather",
+                            "response": {"temperature": 22, "conditions": "sunny"},
+                        }
+                    }
+                ],
+            },
+        ],
+        config=GenerateContentConfig(
+            tools=[
+                Tool(
+                    function_declarations=[
+                        FunctionDeclaration(
+                            name="get_weather",
+                            description="Get the weather for a location",
+                            parameters=Schema(
+                                type=Type.OBJECT,
+                                properties={
+                                    "location": Schema(type=Type.STRING),
+                                    "units": Schema(type=Type.STRING),
+                                },
+                                required=["location"],
+                            ),
+                        )
+                    ]
+                )
+            ]
+        ),
+    )
+
+    assert isinstance(response, GenerateContentResponse)
+    assert response.text
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "gen_ai.request.functions": ("get_weather",),
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "jbSeaO33Hci9698PtLOnoA4",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 38,
+                "gen_ai.usage.output_tokens": 17,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "What's the weather in Tokyo?",
+                    },
+                },
+                {
+                    "name": "gen_ai.model.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.tool_calls": '[{"id": "tool_0", "type": "function", "function": {"name": "get_weather", "arguments": "{\\"location\\": \\"Tokyo\\", \\"units\\": \\"celsius\\"}"}}]',
+                    },
+                },
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {"gen_ai.system": "google_genai"},
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "content": "The weather in Tokyo is sunny with a temperature of 22 degrees Celsius.\\n"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+class WeatherToolPydantic(BaseModel):
+    """Pydantic model for weather tool."""
+
+    location: str
+    units: str = "celsius"
+
+
+class WeatherToolTypedDict(TypedDict):
+    """TypedDict for weather tool."""
+
+    location: str
+    units: str
+
+
+@pytest.mark.vcr()
+def test_sync_generate_content_with_typeddict_tool(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test generation with TypedDict-based tool."""
+    weather_tool_typed: WeatherToolTypedDict = {
+        "location": "London",
+        "units": "fahrenheit",
+    }
+
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=f"The weather in {weather_tool_typed['location']} is 65 degrees {weather_tool_typed['units']}. Summarize this.",
+    )
+
+    assert isinstance(response, GenerateContentResponse)
+    assert response.text
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "jrSeaMj3MZvB698Pr82s8Ac",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 16,
+                "gen_ai.usage.output_tokens": 16,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "The weather in London is 65 degrees fahrenheit. Summarize this.",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "content": "The weather in London is mild and pleasant at 65 degrees Fahrenheit.\\n"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_generate_content_with_dict_config(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test generation with dict-based config (TypedDict pattern)."""
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents="Say hello",
+        config=GenerateContentConfigDict(
+            temperature=0.5,
+            top_p=0.9,
+            top_k=30,
+            max_output_tokens=50,
+            system_instruction="You are a helpful assistant.",
+        ),
+    )
+
+    assert isinstance(response, GenerateContentResponse)
+    assert response.text
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.request.temperature": 0.5,
+                "gen_ai.request.top_p": 0.9,
+                "gen_ai.request.top_k": 30,
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.system": "google_genai",
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "j7SeaPPQGKn9698P0-izuAo",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 8,
+                "gen_ai.usage.output_tokens": 10,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.system.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "You are a helpful assistant.",
+                    },
+                },
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "Say hello",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "content": "Hello! How can I help you today?\\n"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_generate_content_with_content_dict(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test generation with ContentDict (TypedDict pattern)."""
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=ContentDict(
+            role="user",
+            parts=[
+                PartDict(text="What is 2+2?"),
+            ],
+        ),
+    )
+
+    assert isinstance(response, GenerateContentResponse)
+    assert response.text
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat gemini-2.0-flash-exp",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.request.model": "gemini-2.0-flash-exp",
+                "gen_ai.system": "google_genai",
+                "gen_ai.response.model": "gemini-2.0-flash-exp",
+                "gen_ai.response.id": "kLSeaNUNtYOb0g_6_eWBBg",
+                "gen_ai.response.finish_reasons": ("STOP",),
+                "gen_ai.usage.input_tokens": 7,
+                "gen_ai.usage.output_tokens": 8,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.content": "What is 2+2?",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "google_genai",
+                        "gen_ai.choice.index": 0,
+                        "gen_ai.choice.finish_reason": "STOP",
+                        "gen_ai.choice.message": '{"role": "model", "content": "2 + 2 = 4\\n"}',
+                    },
+                },
+            ],
+        }
+    )
+
+
+def test_instrument_unknown_client_class(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test instrumentation with unknown client class."""
+
+    class UnknownClient:
+        """A client class that is not Models or AsyncModels."""
+
+        pass
+
+    mock_client = UnknownClient()
+
+    with caplog.at_level("WARNING"):
+        instrument_google(mock_client)  # type: ignore[arg-type]
+
+    assert "Unknown Google GenAI client class" in caplog.text
+    assert not hasattr(mock_client, "_lilypad_instrumented")
+
+
+def test_instrument_models_with_readonly_generate_content(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test instrumentation when generate_content is read-only to cover lines 52-53."""
+    mock_models = Mock(spec=Models)
+    type(mock_models).generate_content = property(lambda self: Mock())
+
+    with caplog.at_level("WARNING"):
+        instrument_google(mock_models)
+
+    assert hasattr(mock_models, "_lilypad_instrumented")
+    assert mock_models._lilypad_instrumented is True
+    assert "Failed to wrap generate_content: AttributeError" in caplog.text
+
+
+@pytest.mark.vcr()
+def test_generate_with_typeddict_config_and_content(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test with TypedDict-based config and content."""
+    config_dict = GenerateContentConfigDict(
+        temperature=0.7,
+        top_p=0.9,
+        top_k=40,
+        max_output_tokens=100,
+        stop_sequences=["END"],
+        presence_penalty=0.1,
+        frequency_penalty=0.2,
+        system_instruction="You are a helpful assistant",
+    )
+
+    content_dict = ContentDict(
+        role="user",
+        parts=[
+            PartDict(text="What is 1+1?"),
+        ],
+    )
+
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=[content_dict],
+        config=config_dict,
+    )
+
+    assert response.text
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+@pytest.mark.vcr()
+def test_generate_with_pydantic_config_and_content(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test with Pydantic-based config and content."""
+
+    config = GenerateContentConfig(
+        temperature=0.7,
+        top_p=0.9,
+        top_k=40,
+        max_output_tokens=100,
+        stop_sequences=["END"],
+        presence_penalty=0.1,
+        frequency_penalty=0.2,
+        system_instruction="You are a helpful assistant",
+    )
+
+    content = Content(
+        role="user",
+        parts=[
+            Part(text="What is 1+1?"),
+        ],
+    )
+
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=[content],
+        config=config,
+    )
+
+    assert response.text
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+@pytest.mark.vcr()
+def test_sync_generate_with_no_contents(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test generation with missing contents to cover early return."""
+    from contextlib import suppress
+
+    with suppress(Exception):
+        response = client.generate_content(
+            model="gemini-2.0-flash-exp",
+            contents="",
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    span_data = extract_span_data(spans[0])
+    events = span_data.get("events", [])
+    user_messages = [e for e in events if e["name"] == "gen_ai.user.message"]
+    assert len(user_messages) == 0
+
+
+@pytest.mark.vcr()
+def test_multi_turn_with_function_response_typeddict(
+    client: Models, span_exporter: InMemorySpanExporter
+) -> None:
+    """Test multi-turn conversation with function response using TypedDict."""
+    get_weather = FunctionDeclaration(
+        name="get_weather",
+        description="Get the weather",
+        parameters=Schema(
+            type=Type.OBJECT,
+            properties={
+                "location": Schema(
+                    type=Type.STRING,
+                ),
+            },
+            required=["location"],
+        ),
+    )
+
+    tool = Tool(function_declarations=[get_weather])
+
+    contents_list: ContentListUnionDict = [
+        ContentDict(role="user", parts=[PartDict(text="What's the weather in Paris?")]),
+        ContentDict(
+            role="model",
+            parts=[
+                PartDict(
+                    function_call=FunctionCallDict(
+                        name="get_weather", args={"location": "Paris"}
+                    )
+                )
+            ],
+        ),
+        ContentDict(
+            role="user",
+            parts=[
+                PartDict(
+                    function_response=FunctionResponseDict(
+                        name="get_weather",
+                        response={"temperature": "15C", "conditions": "sunny"},
+                    )
+                )
+            ],
+        ),
+    ]
+
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=contents_list,
+        config=GenerateContentConfig(tools=[tool]),
+    )
+
+    assert response
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+@pytest.mark.vcr()
+def test_generate_with_dict_tools(
+    client: Models,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test dict-based tools to cover lines 155-171."""
+    tool_dict = ToolDict(
+        function_declarations=[
+            FunctionDeclarationDict(
+                name="search_database",
+                description="Search for information in database",
+                parameters=SchemaDict(
+                    type=Type.OBJECT,
+                    properties={
+                        "query": SchemaDict(type=Type.STRING),
+                        "limit": SchemaDict(type=Type.INTEGER),
+                    },
+                    required=["query"],
+                ),
+            ),
+            FunctionDeclarationDict(
+                name="get_user_info",
+                description="Get user information",
+                parameters=SchemaDict(
+                    type=Type.OBJECT,
+                    properties={
+                        "user_id": SchemaDict(type=Type.STRING),
+                    },
+                    required=["user_id"],
+                ),
+            ),
+        ]
+    )
+
+    config_dict = GenerateContentConfigDict(temperature=0.5, tools=[tool_dict])
+
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents="Search for AI news",
+        config=config_dict,
+    )
+
+    assert response
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_data = extract_span_data(spans[0])
+    assert span_data["attributes"]["gen_ai.request.functions"] == snapshot(
+        ("search_database", "get_user_info")
+    )
+
+
+@pytest.mark.vcr()
+def test_generate_with_inline_data_bytes(
+    client: Models,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test inline_data with bytes to cover lines 370-377, 385-391."""
+
+    image_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+    )
+
+    contents: ContentListUnionDict = [
+        ContentDict(
+            role="user",
+            parts=[
+                PartDict(text="What is in this image?"),
+                PartDict(inline_data=BlobDict(mime_type="image/png", data=image_bytes)),
+            ],
+        )
+    ]
+
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=contents,
+    )
+
+    assert response
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_data = extract_span_data(spans[0])
+    events = span_data["events"]
+    assert len(events) >= 1
+    user_message_event = events[0]
+    assert user_message_event["name"] == "gen_ai.user.message"
+    user_message = user_message_event["attributes"]["gen_ai.content"]
+    assert "What is in this image?" in user_message
+
+
+@pytest.mark.vcr()
+def test_generate_with_part_instance(
+    client: Models,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test Part instance in content to cover line 313."""
+
+    part = Part(text="Explain quantum computing in simple terms")
+
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=part,
+    )
+
+    assert response
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_data = extract_span_data(spans[0])
+    events = span_data["events"]
+    assert len(events) >= 1
+    user_message_event = events[0]
+    assert user_message_event["name"] == "gen_ai.user.message"
+    user_message = user_message_event["attributes"]["gen_ai.content"]
+    assert "Explain quantum computing" in user_message
+
+
+@pytest.mark.vcr()
+def test_generate_with_mixed_content_types(
+    client: Models,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test mixed content types to cover line 324."""
+
+    contents = [
+        "Simple string content",
+        Content(parts=[Part(text="Content object with Part")], role="user"),
+        {"parts": [{"text": "Dict-based content"}]},
+        Part(text="Direct Part object"),
+    ]
+
+    for content in contents:
+        response = client.generate_content(
+            model="gemini-2.0-flash-exp",
+            contents=content,
+        )
+        assert response
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 4
+
+
+@pytest.mark.vcr()
+def test_generate_with_part_dict_without_parts_wrapper(
+    client: Models,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test part dict without parts wrapper to cover line 185 in _utils.py."""
+    part = Part(text="Test content without parts wrapper")
+
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=[part],
+    )
+
+    assert response
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    events = extract_span_data(spans[0])["events"]
+    assert len(events) >= 1
+    user_message_event = events[0]
+    assert user_message_event["name"] == "gen_ai.user.message"
+    assert (
+        "Test content without parts wrapper"
+        in user_message_event["attributes"]["gen_ai.content"]
+    )
+
+
+@pytest.mark.vcr()
+def test_generate_with_base64_string_inline_data(
+    client: Models,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test inline_data with base64 string to cover line 238 in _utils.py."""
+    base64_string = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+
+    content = Content(
+        parts=[
+            Part(text="Analyze this base64 encoded image"),
+            Part(
+                inline_data=Blob(
+                    mime_type="image/png", data=base64.b64decode(base64_string)
+                )
+            ),
+        ],
+        role="user",
+    )
+
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=content,
+    )
+
+    assert response
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    events = extract_span_data(spans[0])["events"]
+    assert len(events) >= 1
+    user_message_event = events[0]
+    assert user_message_event["name"] == "gen_ai.user.message"
+    assert (
+        "Analyze this base64 encoded image"
+        in user_message_event["attributes"]["gen_ai.content"]
+    )
+
+
+@pytest.mark.vcr()
+def test_generate_with_webp_image(
+    client: Models,
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test WebP image handling to cover lines 179-194 in _utils.py."""
+    img = Image.new("RGB", (1, 1), color="red")
+    buffer = BytesIO()
+    img.save(buffer, format="WEBP")
+    webp_bytes = buffer.getvalue()
+
+    webp_img = Image.open(BytesIO(webp_bytes))
+
+    response = client.generate_content(
+        model="gemini-2.0-flash-exp",
+        contents=[webp_img],
+    )
+
+    assert response
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    events = extract_span_data(spans[0])["events"]
+    assert len(events) >= 1
+    user_message_event = events[0]
+    assert user_message_event["name"] == "gen_ai.user.message"
+    assert user_message_event["attributes"]["gen_ai.system"] == "google_genai"


### PR DESCRIPTION
### TL;DR

Add VCR.py test cassettes for Google GenAI instrumentation tests and configure inline-snapshot formatting.

### What changed?

- Added configuration for `inline-snapshot` in `pyproject.toml` to format snapshots with ruff
- Created a comprehensive test suite for Google GenAI instrumentation with VCR.py cassettes
- Added test cases covering various scenarios:
  - Basic content generation (sync and async)
  - Streaming responses
  - Function calling
  - Error handling
  - Different content and configuration formats (dict, TypedDict, Pydantic)
  - Multi-turn conversations
  - Advanced configuration parameters

### How to test?

Run the Python tests for the Google GenAI instrumentation:

```bash
cd sdks/python
pytest tests/lilypad/_internal/otel/google/test_instrument.py -v
```

### Why make this change?

This change adds proper test coverage for the Google GenAI instrumentation module, ensuring it correctly traces API calls and handles various scenarios. The VCR.py cassettes allow tests to run without making actual API calls, making the test suite more reliable and faster. The inline-snapshot formatting ensures consistent and readable snapshot assertions in the tests.