### PR TITLE
Port Azure OpenTelemetry into Lilypad v1

### DIFF
--- a/sdks/python/examples/instrument_azure_with_console.py
+++ b/sdks/python/examples/instrument_azure_with_console.py
@@ -1,0 +1,68 @@
+import os
+import lilypad
+from azure.ai.inference import ChatCompletionsClient
+from azure.ai.inference.models import SystemMessage, UserMessage
+from azure.core.credentials import AzureKeyCredential
+from opentelemetry import trace
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.sdk.trace import TracerProvider
+
+# Export spans to the console.
+otlp_exporter = ConsoleSpanExporter()
+processor = SimpleSpanProcessor(otlp_exporter)
+provider = TracerProvider(id_generator=lilypad.configuration.CryptoIdGenerator())
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+
+lilypad.configure()  # will log that a tracer has already been configured, which is ok
+
+# Initialize Azure AI Inference client
+endpoint = os.getenv("AZURE_INFERENCE_ENDPOINT")
+credential = os.getenv("AZURE_INFERENCE_CREDENTIAL")
+
+if not endpoint or not credential:
+    raise ValueError("Please set AZURE_INFERENCE_ENDPOINT and AZURE_INFERENCE_CREDENTIAL environment variables")
+
+client = ChatCompletionsClient(
+    endpoint=endpoint,
+    credential=AzureKeyCredential(credential),
+    api_version="2024-05-01-preview"
+)
+
+# Instrument the client
+lilypad.instrument_azure(client)
+
+# Non-streaming example
+print("Non-streaming example:")
+response = client.complete(
+    messages=[
+        SystemMessage(content="You are a helpful assistant."),
+        UserMessage(content="Hello! How's it going?"),
+    ],
+    model="Ministral-3B-hgtva",  # or your deployed model name
+    max_tokens=100,
+    temperature=0.7,
+)
+
+if response.choices:
+    print(response.choices[0].message.content)
+
+print("\n" + "="*50 + "\n")
+
+# Streaming example
+print("Streaming example:")
+stream_response = client.complete(
+    messages=[
+        SystemMessage(content="You are a helpful assistant."),
+        UserMessage(content="Count from 1 to 5 and say goodbye."),
+    ],
+    model="Ministral-3B-hgtva",  # or your deployed model name
+    max_tokens=100,
+    temperature=0.7,
+    stream=True
+)
+
+for chunk in stream_response:
+    if chunk.choices and chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+print()  # New line after streaming

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 openai = ["openai>=1.98.0"]
 anthropic = ["anthropic>=0.63.0"]
 google = ["google-genai>=1.30.0,<2", "pillow>=10.4.0,<12", "proto-plus>=1.26.1"]
+azure = ["azure-ai-inference>=1.0.0b9"]
 
 [dependency-groups]
 dev = ["pyright>=1.1.403", "ruff>=0.12.7", "pre-commit>=3.5.0"]
@@ -45,7 +46,7 @@ test = [
     "inline-snapshot>=0.23.0",
     "python-dotenv>=1.1.1",
 ]
-examples = ["openai>=1.98.0", "anthropic>=0.63.0", "google-genai>=1.7.0,<2"]
+examples = ["openai>=1.98.0", "anthropic>=0.63.0", "google-genai>=1.7.0,<2", "azure-ai-inference>=1.0.0b9"]
 
 [build-system]
 requires = ["uv_build>=0.8.4,<0.9.0"]

--- a/sdks/python/src/lilypad/__init__.py
+++ b/sdks/python/src/lilypad/__init__.py
@@ -14,10 +14,14 @@ with suppress(ImportError):
 with suppress(ImportError):
     from ._internal.otel import instrument_google
 
+with suppress(ImportError):
+    from ._internal.otel import instrument_azure
+
 __all__ = [
     "configuration",
     "configure",
     "instrument_anthropic",
+    "instrument_azure",
     "instrument_google",
     "instrument_openai",
 ]

--- a/sdks/python/src/lilypad/_internal/otel/__init__.py
+++ b/sdks/python/src/lilypad/_internal/otel/__init__.py
@@ -11,8 +11,12 @@ with suppress(ImportError):
 with suppress(ImportError):
     from .google import instrument_google as instrument_google
 
+with suppress(ImportError):
+    from .azure import instrument_azure as instrument_azure
+
 __all__ = [
     "instrument_anthropic",
+    "instrument_azure",
     "instrument_google",
     "instrument_openai",
 ]

--- a/sdks/python/src/lilypad/_internal/otel/azure/__init__.py
+++ b/sdks/python/src/lilypad/_internal/otel/azure/__init__.py
@@ -1,0 +1,5 @@
+"""Azure AI Inference instrumentation module for OpenTelemetry integration."""
+
+from .instrument import instrument_azure
+
+__all__ = ["instrument_azure"]

--- a/sdks/python/src/lilypad/_internal/otel/azure/_patch.py
+++ b/sdks/python/src/lilypad/_internal/otel/azure/_patch.py
@@ -1,0 +1,94 @@
+"""Patching utilities for Azure AI Inference client methods to add OpenTelemetry instrumentation.
+
+This module contains the core logic for wrapping Azure AI Inference API calls with telemetry spans.
+"""
+
+from typing import Any, ParamSpec
+
+from opentelemetry.trace import Span, Tracer
+
+from . import _utils
+from ..base import (
+    create_sync_wrapper,
+    create_async_wrapper,
+)
+from ..utils import (
+    StreamWrapper,
+    StreamProtocol,
+    AsyncStreamWrapper,
+    AsyncStreamProtocol,
+)
+from ..base.protocols import (
+    SyncStreamHandler,
+    AsyncStreamHandler,
+)
+
+from azure.ai.inference import ChatCompletionsClient
+from azure.ai.inference.aio import ChatCompletionsClient as AsyncChatCompletionsClient
+from azure.ai.inference.models import StreamingChatCompletionsUpdate
+
+P = ParamSpec("P")
+
+
+def _process_messages(span: Span, kwargs: dict[str, Any]) -> None:
+    """Process and record input messages."""
+    for message in kwargs.get("messages", []):
+        _utils.set_message_event(span, message)
+
+
+def _create_stream_wrapper(
+    span: Span, stream: StreamProtocol[StreamingChatCompletionsUpdate]
+) -> StreamWrapper[StreamingChatCompletionsUpdate, _utils.AzureMetadata]:
+    """Create Azure-specific stream wrapper."""
+    return StreamWrapper(
+        span=span,
+        stream=stream,
+        metadata=_utils.AzureMetadata(),
+        chunk_handler=_utils.AzureChunkHandler(),
+        cleanup_handler=_utils.default_azure_cleanup,
+    )
+
+
+async def _create_async_stream_wrapper(
+    span: Span, stream: AsyncStreamProtocol[StreamingChatCompletionsUpdate]
+) -> AsyncStreamWrapper[StreamingChatCompletionsUpdate, _utils.AzureMetadata]:
+    """Create Azure-specific async stream wrapper."""
+    return AsyncStreamWrapper(
+        span=span,
+        stream=stream,
+        metadata=_utils.AzureMetadata(),
+        chunk_handler=_utils.AzureChunkHandler(),
+        cleanup_handler=_utils.default_azure_cleanup,
+    )
+
+
+def chat_completions_complete_patch_factory(
+    tracer: Tracer,
+) -> SyncStreamHandler[
+    P, StreamingChatCompletionsUpdate, _utils.AzureMetadata, ChatCompletionsClient
+]:
+    """Returns a patch factory for sync chat completions complete method."""
+    return create_sync_wrapper(
+        tracer=tracer,
+        get_span_attributes=_utils.get_llm_request_attributes,
+        process_messages=_process_messages,
+        process_response=_utils.set_response_attributes,
+        create_stream_wrapper=_create_stream_wrapper,
+        handle_stream=True,
+    )
+
+
+def chat_completions_complete_async_patch_factory(
+    tracer: Tracer,
+) -> AsyncStreamHandler[
+    P, StreamingChatCompletionsUpdate, _utils.AzureMetadata, AsyncChatCompletionsClient
+]:
+    """Returns a patch factory for async chat completions complete method."""
+    return create_async_wrapper(
+        tracer=tracer,
+        get_span_attributes=_utils.get_llm_request_attributes,
+        process_messages=_process_messages,
+        process_response=_utils.set_response_attributes,
+        create_async_stream_wrapper=_create_async_stream_wrapper,
+        handle_stream=True,
+    )

--- a/sdks/python/src/lilypad/_internal/otel/azure/_utils.py
+++ b/sdks/python/src/lilypad/_internal/otel/azure/_utils.py
@@ -1,0 +1,376 @@
+"""Utility functions for Azure AI Inference OpenTelemetry instrumentation.
+
+This module provides helper functions for extracting and formatting Azure AI Inference API
+response data for telemetry purposes.
+"""
+
+import json
+from typing import Any, Protocol, TypedDict, Literal
+
+from opentelemetry.trace import Span
+from opentelemetry.util.types import AttributeValue
+from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
+
+from ..utils import (
+    BaseMetadata,
+    ChoiceBuffer,
+    ChunkHandler,
+    set_server_address_and_port,
+)
+from ...utils import json_dumps
+
+from azure.ai.inference import ChatCompletionsClient
+from azure.ai.inference.aio import ChatCompletionsClient as AsyncChatCompletionsClient
+from azure.ai.inference.models import (
+    ChatCompletions,
+    StreamingChatCompletionsUpdate,
+    ChatResponseMessage,
+    ChatRequestMessage,
+    ChatCompletionsToolCall,
+    CompletionsUsage,
+    StreamingChatChoiceUpdate,
+    ChatChoice,
+    StreamingChatResponseToolCallUpdate,
+    FunctionCall,
+)
+
+
+class FunctionCallDict(TypedDict):
+    """TypedDict for function call structure."""
+
+    name: str
+    arguments: str
+
+
+class ToolCallDict(TypedDict):
+    """TypedDict for tool call structure."""
+
+    id: str
+    type: Literal["function"]
+    function: FunctionCallDict
+
+
+class MessageDict(TypedDict, total=False):
+    """TypedDict for message structure."""
+
+    role: str
+    content: str
+    tool_calls: list[ToolCallDict]
+
+
+class IndexedToolCall:
+    """Wrapper to add index property to Azure streaming tool calls."""
+
+    def __init__(
+        self,
+        tool_call: StreamingChatResponseToolCallUpdate,
+        index: int,
+    ):
+        self._tool_call = tool_call
+        self._index = index
+
+    @property
+    def index(self) -> int:
+        return self._index
+
+    @property
+    def id(self) -> str | None:
+        return self._tool_call.id if self._tool_call.id else None
+
+    @property
+    def function(self) -> FunctionCall | None:
+        return self._tool_call.function if self._tool_call.function else None
+
+
+class AzureMetadata(BaseMetadata, total=False):
+    """Azure-specific metadata extending BaseMetadata."""
+
+    finish_reasons: list[str]
+
+
+class AzureMessageProtocol(Protocol):
+    """Protocol for Azure chat messages."""
+
+    role: str
+    content: str | None
+    tool_calls: list[ChatCompletionsToolCall] | None
+
+
+class AzureChoiceProtocol(Protocol):
+    """Protocol for Azure chat choices."""
+
+    index: int
+    message: ChatResponseMessage
+    finish_reason: str | None
+
+
+class AzureCompletionProtocol(Protocol):
+    """Protocol for Azure chat completions."""
+
+    id: str
+    model: str
+    choices: list[ChatChoice]
+    usage: CompletionsUsage | None
+
+
+class AzureStreamChunkProtocol(Protocol):
+    """Protocol for Azure streaming chunks."""
+
+    id: str | None
+    model: str | None
+    choices: list[StreamingChatChoiceUpdate]
+    usage: CompletionsUsage | None
+
+
+class AzureChunkHandler(ChunkHandler[StreamingChatCompletionsUpdate, AzureMetadata]):
+    def extract_metadata(
+        self, chunk: StreamingChatCompletionsUpdate, metadata: AzureMetadata
+    ) -> None:
+        """Extract metadata from a streaming chunk and update the metadata dictionary."""
+        if not metadata.get("response_model") and chunk.model:
+            metadata["response_model"] = chunk.model
+        if not metadata.get("response_id") and chunk.id:
+            metadata["response_id"] = chunk.id
+        if usage := chunk.usage:
+            if completion_tokens := usage.completion_tokens:
+                metadata["completion_tokens"] = completion_tokens
+            if prompt_tokens := usage.prompt_tokens:
+                metadata["prompt_tokens"] = prompt_tokens
+
+    def process_chunk(
+        self, chunk: StreamingChatCompletionsUpdate, buffers: list[ChoiceBuffer]
+    ) -> None:
+        """Process a streaming chunk and update the choice buffers with content."""
+        for choice in chunk.choices:
+            while len(buffers) <= choice.index:
+                buffers.append(ChoiceBuffer(len(buffers)))
+
+            if finish_reason := choice.finish_reason:
+                buffers[choice.index].finish_reason = str(finish_reason)
+
+            if delta := choice.delta:
+                if delta.content is not None:
+                    buffers[choice.index].append_text_content(delta.content)
+
+                if tool_calls := delta.tool_calls:
+                    for index, tool_call in enumerate(tool_calls):
+                        indexed_tool_call = IndexedToolCall(tool_call, index)
+                        buffers[choice.index].append_tool_call(indexed_tool_call)
+
+
+def default_azure_cleanup(
+    span: Span, metadata: AzureMetadata, buffers: list[ChoiceBuffer]
+) -> None:
+    """Set final span attributes and events from accumulated metadata and buffers."""
+    attributes: dict[str, AttributeValue] = {}
+    if response_model := metadata.get("response_model"):
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_MODEL] = response_model
+    if response_id := metadata.get("response_id"):
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_ID] = response_id
+    if prompt_tokens := metadata.get("prompt_tokens"):
+        attributes[gen_ai_attributes.GEN_AI_USAGE_INPUT_TOKENS] = prompt_tokens
+    if completion_tokens := metadata.get("completion_tokens"):
+        attributes[gen_ai_attributes.GEN_AI_USAGE_OUTPUT_TOKENS] = completion_tokens
+
+    if finish_reasons := tuple(
+        str(buffer.finish_reason)
+        for buffer in buffers
+        if buffer.finish_reason is not None
+    ):
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_FINISH_REASONS] = finish_reasons
+
+    span.set_attributes(attributes)
+    for index, choice in enumerate(buffers):
+        message: MessageDict = {"role": "assistant"}
+        if text_content := choice.text_content:
+            message["content"] = "".join(text_content)
+        if tool_calls_buffers := choice.tool_calls_buffers:
+            tool_calls: list[ToolCallDict] = []
+            for tool_call in tool_calls_buffers:
+                if tool_call:
+                    function: FunctionCallDict = {
+                        "name": tool_call.function_name,
+                        "arguments": "".join(tool_call.arguments),
+                    }
+                    tool_call_dict: ToolCallDict = {
+                        "id": tool_call.tool_call_id,
+                        "type": "function",
+                        "function": function,
+                    }
+                    tool_calls.append(tool_call_dict)
+            message["tool_calls"] = tool_calls
+
+        event_attributes: dict[str, AttributeValue] = {
+            gen_ai_attributes.GEN_AI_SYSTEM: gen_ai_attributes.GenAiSystemValues.AZ_AI_INFERENCE.value,
+            "index": index,
+            "finish_reason": str(choice.finish_reason)
+            if choice.finish_reason
+            else "none",
+            "message": json.dumps(message),
+        }
+        span.add_event("gen_ai.choice", attributes=event_attributes)
+
+
+def get_tool_calls(
+    message: ChatResponseMessage | ChatRequestMessage | dict[str, Any],
+) -> list[ToolCallDict] | None:
+    """Returns tool calls extracted from a message object or dictionary."""
+
+    if isinstance(message, dict):
+        tool_calls = message.get("tool_calls")
+    else:
+        tool_calls = getattr(message, "tool_calls", None)
+
+    if not tool_calls:
+        return None
+
+    calls: list[ToolCallDict] = []
+    for tool_call in tool_calls:
+        if isinstance(tool_call, dict):
+            call_id = tool_call.get("id", "")
+            if func := tool_call.get("function"):
+                function_dict: FunctionCallDict = {
+                    "name": func.get("name", ""),
+                    "arguments": func.get("arguments", ""),
+                }
+                tool_call_dict: ToolCallDict = {
+                    "id": call_id,
+                    "type": "function",
+                    "function": function_dict,
+                }
+                calls.append(tool_call_dict)
+        else:
+            if function := tool_call.function:
+                function_dict: FunctionCallDict = {
+                    "name": function.name,
+                    "arguments": function.arguments,
+                }
+                tool_call_dict: ToolCallDict = {
+                    "id": tool_call.id,
+                    "type": "function",
+                    "function": function_dict,
+                }
+                calls.append(tool_call_dict)
+    return calls
+
+
+def set_message_event(span: Span, message: ChatRequestMessage | dict[str, Any]) -> None:
+    """Add a message event to the span with appropriate attributes."""
+    attributes: dict[str, AttributeValue] = {
+        gen_ai_attributes.GEN_AI_SYSTEM: gen_ai_attributes.GenAiSystemValues.AZ_AI_INFERENCE.value
+    }
+
+    if isinstance(message, dict):
+        role = message.get("role", "")
+        content = message.get("content")
+        tool_call_id = message.get("tool_call_id")
+    else:
+        role = getattr(message, "role", "")
+        content = getattr(message, "content", None)
+        tool_call_id = getattr(message, "tool_call_id", None)
+
+    if role == "assistant" and (tool_calls := get_tool_calls(message)):
+        attributes["tool_calls"] = json_dumps(tool_calls)
+
+    if role == "tool" and tool_call_id:
+        attributes["id"] = tool_call_id
+
+    if content is not None:
+        if not isinstance(content, str):
+            content = json_dumps(content)
+        attributes["content"] = content
+
+    span.add_event(
+        f"gen_ai.{role}.message",
+        attributes=attributes,
+    )
+
+
+def get_choice_event(choice: ChatChoice) -> dict[str, AttributeValue]:
+    """Extract event attributes from a choice object."""
+    attributes: dict[str, AttributeValue] = {
+        gen_ai_attributes.GEN_AI_SYSTEM: gen_ai_attributes.GenAiSystemValues.AZ_AI_INFERENCE.value
+    }
+
+    message_dict: MessageDict = {"role": choice.message.role}
+    if content := choice.message.content:
+        message_dict["content"] = content
+    if tool_calls := get_tool_calls(choice.message):
+        message_dict["tool_calls"] = tool_calls
+
+    attributes["message"] = json.dumps(message_dict)
+    attributes["index"] = choice.index
+    attributes["finish_reason"] = (
+        str(choice.finish_reason) if choice.finish_reason else "none"
+    )
+    return attributes
+
+
+def set_response_attributes(span: Span, response: ChatCompletions) -> None:
+    """Set span attributes from non-streaming response."""
+    attributes: dict[str, AttributeValue] = {}
+
+    if model := response.model:
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_MODEL] = model
+
+    if choices := response.choices:
+        finish_reasons = []
+        for choice in choices:
+            choice_attributes = get_choice_event(choice)
+            span.add_event(
+                "gen_ai.choice",
+                attributes=choice_attributes,
+            )
+            if finish_reason := choice.finish_reason:
+                finish_reasons.append(str(finish_reason))
+        if finish_reasons:
+            attributes[gen_ai_attributes.GEN_AI_RESPONSE_FINISH_REASONS] = tuple(
+                finish_reasons
+            )
+
+    if response_id := response.id:
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_ID] = response_id
+
+    if usage := response.usage:
+        if prompt_tokens := usage.prompt_tokens:
+            attributes[gen_ai_attributes.GEN_AI_USAGE_INPUT_TOKENS] = prompt_tokens
+        if completion_tokens := usage.completion_tokens:
+            attributes[gen_ai_attributes.GEN_AI_USAGE_OUTPUT_TOKENS] = completion_tokens
+
+    span.set_attributes(attributes)
+
+
+def get_llm_request_attributes(
+    kwargs: dict[str, Any],
+    client: ChatCompletionsClient | AsyncChatCompletionsClient,
+    operation_name: str = gen_ai_attributes.GenAiOperationNameValues.CHAT.value,
+) -> dict[str, AttributeValue]:
+    """Extract span attributes from request kwargs and client."""
+    attributes: dict[str, AttributeValue] = {
+        gen_ai_attributes.GEN_AI_OPERATION_NAME: operation_name,
+        gen_ai_attributes.GEN_AI_SYSTEM: gen_ai_attributes.GenAiSystemValues.AZ_AI_INFERENCE.value,
+    }
+
+    if model := kwargs.get("model"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_MODEL] = model
+
+    if temperature := kwargs.get("temperature"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_TEMPERATURE] = temperature
+
+    if max_tokens := kwargs.get("max_tokens"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_MAX_TOKENS] = max_tokens
+
+    if top_p := kwargs.get("top_p"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_TOP_P] = top_p
+
+    if frequency_penalty := kwargs.get("frequency_penalty"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_FREQUENCY_PENALTY] = (
+            frequency_penalty
+        )
+
+    if presence_penalty := kwargs.get("presence_penalty"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_PRESENCE_PENALTY] = presence_penalty
+
+    set_server_address_and_port(client, attributes)
+
+    return attributes

--- a/sdks/python/src/lilypad/_internal/otel/azure/instrument.py
+++ b/sdks/python/src/lilypad/_internal/otel/azure/instrument.py
@@ -1,0 +1,72 @@
+"""Azure AI Inference client instrumentation for OpenTelemetry tracing.
+
+This module provides instrumentation for the Azure AI Inference Python client to automatically
+create OpenTelemetry spans for API calls.
+"""
+
+import logging
+from importlib.metadata import PackageNotFoundError, version
+
+from wrapt import FunctionWrapper
+from opentelemetry.trace import get_tracer
+from opentelemetry.semconv.schemas import Schemas
+
+from . import _patch
+
+
+from azure.ai.inference import ChatCompletionsClient
+from azure.ai.inference.aio import ChatCompletionsClient as AsyncChatCompletionsClient
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: see if we can refactor this with other providers in a way that makes sense
+def instrument_azure(
+    client: ChatCompletionsClient | AsyncChatCompletionsClient,
+) -> None:
+    """
+    Instrument the Azure AI Inference client with OpenTelemetry tracing.
+
+    Args:
+        client: The Azure ChatCompletionsClient instance to instrument.
+    """
+    if hasattr(client, "_lilypad_instrumented"):
+        logger.debug(f"{type(client).__name__} already instrumented, skipping")
+        return
+
+    try:
+        lilypad_version = version("lilypad-sdk")
+    except PackageNotFoundError:
+        lilypad_version = "unknown"
+        logger.debug("Could not determine lilypad-sdk version")
+
+    tracer = get_tracer(
+        __name__,
+        lilypad_version,
+        schema_url=Schemas.V1_28_0.value,
+    )
+
+    if isinstance(client, AsyncChatCompletionsClient):
+        try:
+            client.complete = FunctionWrapper(
+                client.complete,
+                _patch.chat_completions_complete_async_patch_factory(tracer),
+            )
+            logger.debug("Successfully wrapped AsyncChatCompletionsClient.complete")
+        except Exception as e:
+            logger.warning(
+                f"Failed to wrap AsyncChatCompletionsClient.complete: {type(e).__name__}: {e}"
+            )
+    else:
+        try:
+            client.complete = FunctionWrapper(
+                client.complete,
+                _patch.chat_completions_complete_patch_factory(tracer),
+            )
+            logger.debug("Successfully wrapped ChatCompletionsClient.complete")
+        except Exception as e:
+            logger.warning(
+                f"Failed to wrap ChatCompletionsClient.complete: {type(e).__name__}: {e}"
+            )
+
+    client._lilypad_instrumented = True  # pyright: ignore[reportAttributeAccessIssue]

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -58,6 +58,34 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-ai-inference"
+version = "1.0.0b9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/6a/ed85592e5c64e08c291992f58b1a94dab6869f28fb0f40fd753dced73ba6/azure_ai_inference-1.0.0b9.tar.gz", hash = "sha256:1feb496bd84b01ee2691befc04358fa25d7c344d8288e99364438859ad7cd5a4", size = 182408, upload-time = "2025-02-15T00:37:28.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/0f/27520da74769db6e58327d96c98e7b9a07ce686dff582c9a5ec60b03f9dd/azure_ai_inference-1.0.0b9-py3-none-any.whl", hash = "sha256:49823732e674092dad83bb8b0d1b65aa73111fab924d61349eb2a8cdc0493990", size = 124885, upload-time = "2025-02-15T00:37:29.964Z" },
+]
+
+[[package]]
+name = "azure-core"
+version = "1.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "six" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/89/f53968635b1b2e53e4aad2dd641488929fef4ca9dfb0b97927fa7697ddf3/azure_core-1.35.0.tar.gz", hash = "sha256:c0be528489485e9ede59b6971eb63c1eaacf83ef53001bfe3904e475e972be5c", size = 339689, upload-time = "2025-07-03T00:55:23.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/78/bf94897361fdd650850f0f2e405b2293e2f12808239046232bdedf554301/azure_core-1.35.0-py3-none-any.whl", hash = "sha256:8db78c72868a58f3de8991eb4d22c4d368fae226dac1002998d6c50437e7dad1", size = 210708, upload-time = "2025-07-03T00:55:25.238Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -430,6 +458,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -519,6 +556,9 @@ dependencies = [
 anthropic = [
     { name = "anthropic" },
 ]
+azure = [
+    { name = "azure-ai-inference" },
+]
 google = [
     { name = "google-genai" },
     { name = "pillow" },
@@ -536,6 +576,7 @@ dev = [
 ]
 examples = [
     { name = "anthropic" },
+    { name = "azure-ai-inference" },
     { name = "google-genai" },
     { name = "openai" },
 ]
@@ -552,6 +593,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.63.0" },
+    { name = "azure-ai-inference", marker = "extra == 'azure'", specifier = ">=1.0.0b9" },
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.30.0,<2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.98.0" },
@@ -564,7 +606,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "wrapt", specifier = ">=1.17.2" },
 ]
-provides-extras = ["openai", "anthropic", "google"]
+provides-extras = ["openai", "anthropic", "google", "azure"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -574,6 +616,7 @@ dev = [
 ]
 examples = [
     { name = "anthropic", specifier = ">=0.63.0" },
+    { name = "azure-ai-inference", specifier = ">=1.0.0b9" },
     { name = "google-genai", specifier = ">=1.7.0,<2" },
     { name = "openai", specifier = ">=1.98.0" },
 ]
@@ -1407,6 +1450,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/ab/aca2e756ad7b09b3d662a41773f3edcbd262872a4fc81f920dc1ffa44541/ruff-0.12.7-py3-none-win32.whl", hash = "sha256:c928f1b2ec59fb77dfdf70e0419408898b63998789cc98197e15f560b9e77f77", size = 11756687, upload-time = "2025-07-29T22:32:29.381Z" },
     { url = "https://files.pythonhosted.org/packages/b4/71/26d45a5042bc71db22ddd8252ca9d01e9ca454f230e2996bb04f16d72799/ruff-0.12.7-py3-none-win_amd64.whl", hash = "sha256:9c18f3d707ee9edf89da76131956aba1270c6348bfee8f6c647de841eac7194f", size = 12912365, upload-time = "2025-07-29T22:32:31.517Z" },
     { url = "https://files.pythonhosted.org/packages/4c/9b/0b8aa09817b63e78d94b4977f18b1fcaead3165a5ee49251c5d5c245bb2d/ruff-0.12.7-py3-none-win_arm64.whl", hash = "sha256:dfce05101dbd11833a0776716d5d1578641b7fddb537fe7fa956ab85d1769b69", size = 11982083, upload-time = "2025-07-29T22:32:33.881Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### TL;DR

Added Azure AI Inference instrumentation support to the Lilypad SDK.

### What changed?

- Added instrumentation for Azure AI Inference client with OpenTelemetry tracing
- Implemented patching utilities for Azure client methods to add telemetry spans
- Created utility functions for extracting and formatting Azure API response data
- Added a new example demonstrating Azure instrumentation with console output
- Updated dependencies to include `azure-ai-inference` as an optional dependency

### How to test?

1. Install the SDK with Azure support: `pip install lilypad-sdk[azure]`
2. Set environment variables:
   ```
   AZURE_INFERENCE_ENDPOINT=your_endpoint
   AZURE_INFERENCE_CREDENTIAL=your_credential
   ```
3. Run the example:
   ```
   python sdks/python/examples/instrument_azure_with_console.py
   ```
4. Verify that OpenTelemetry spans are generated and printed to the console for both streaming and non-streaming requests

### Why make this change?

This change extends Lilypad's instrumentation capabilities to Azure AI Inference, allowing users to collect telemetry data from Azure LLM API calls. This complements the existing support for OpenAI, Anthropic, and Google, providing a more comprehensive observability solution across major AI providers.