### PR TITLE
Port Mistral OpenTelemetry into Lilypad v1

### DIFF
--- a/sdks/python/examples/instrument_mistral_with_console.py
+++ b/sdks/python/examples/instrument_mistral_with_console.py
@@ -1,0 +1,29 @@
+import os
+
+import lilypad
+from mistralai import Mistral
+from opentelemetry import trace
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.sdk.trace import TracerProvider
+
+# Export spans to the console.
+otlp_exporter = ConsoleSpanExporter()
+processor = SimpleSpanProcessor(otlp_exporter)
+provider = TracerProvider(id_generator=lilypad.configuration.CryptoIdGenerator())
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+
+lilypad.configure()  # will log that a tracer has already been configured, which is ok
+
+client = Mistral(api_key=os.getenv("MISTRAL_API_KEY"))
+lilypad.instrument_mistral(client)
+
+completion = client.chat.complete(
+    model="mistral-small-latest",
+    messages=[{"role": "user", "content": "Hello!"}],
+    max_tokens=50,
+    stream=True
+)
+
+content = completion.choices[0].message.content
+print(content)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -34,6 +34,9 @@ openai = ["openai>=1.98.0"]
 anthropic = ["anthropic>=0.63.0"]
 google = ["google-genai>=1.30.0,<2", "pillow>=10.4.0,<12", "proto-plus>=1.26.1"]
 azure = ["azure-ai-inference>=1.0.0b9", "aiohttp>=3.8.0"]
+mistral = [
+    "mistralai>=1.0.0",
+]
 
 [dependency-groups]
 dev = ["pyright>=1.1.403", "ruff>=0.12.7", "pre-commit>=3.5.0"]
@@ -46,7 +49,7 @@ test = [
     "inline-snapshot>=0.23.0",
     "python-dotenv>=1.1.1",
 ]
-examples = ["openai>=1.98.0", "anthropic>=0.63.0", "google-genai>=1.7.0,<2", "azure-ai-inference>=1.0.0b9", "aiohttp>=3.8.0"]
+examples = ["openai>=1.98.0", "anthropic>=0.63.0", "google-genai>=1.7.0,<2", "azure-ai-inference>=1.0.0b9", "aiohttp>=3.8.0", "mistralai>=1.0.0"]
 
 [build-system]
 requires = ["uv_build>=0.8.4,<0.9.0"]

--- a/sdks/python/src/lilypad/__init__.py
+++ b/sdks/python/src/lilypad/__init__.py
@@ -17,11 +17,15 @@ with suppress(ImportError):
 with suppress(ImportError):
     from ._internal.otel import instrument_azure
 
+with suppress(ImportError):
+    from ._internal.otel import instrument_mistral
+
 __all__ = [
     "configuration",
     "configure",
     "instrument_anthropic",
     "instrument_azure",
     "instrument_google",
+    "instrument_mistral",
     "instrument_openai",
 ]

--- a/sdks/python/src/lilypad/_internal/otel/__init__.py
+++ b/sdks/python/src/lilypad/_internal/otel/__init__.py
@@ -14,9 +14,13 @@ with suppress(ImportError):
 with suppress(ImportError):
     from .azure import instrument_azure as instrument_azure
 
+with suppress(ImportError):
+    from .mistral import instrument_mistral as instrument_mistral
+
 __all__ = [
     "instrument_anthropic",
     "instrument_azure",
     "instrument_google",
+    "instrument_mistral",
     "instrument_openai",
 ]

--- a/sdks/python/src/lilypad/_internal/otel/mistral/__init__.py
+++ b/sdks/python/src/lilypad/_internal/otel/mistral/__init__.py
@@ -1,0 +1,5 @@
+"""Mistral OpenTelemetry instrumentation module."""
+
+from .instrument import instrument_mistral
+
+__all__ = ["instrument_mistral"]

--- a/sdks/python/src/lilypad/_internal/otel/mistral/_patch.py
+++ b/sdks/python/src/lilypad/_internal/otel/mistral/_patch.py
@@ -1,0 +1,88 @@
+"""Patching utilities for Mistral client methods to add OpenTelemetry instrumentation.
+
+This module contains the core logic for wrapping Mistral API calls with telemetry spans.
+"""
+
+from typing import Any, ParamSpec
+
+from mistralai import Mistral
+from mistralai.models import CompletionEvent
+from opentelemetry.trace import Span, Tracer
+
+from . import _utils
+from ..base import (
+    create_sync_wrapper,
+    create_async_wrapper,
+)
+from ..utils import (
+    StreamWrapper,
+    StreamProtocol,
+    AsyncStreamWrapper,
+    AsyncStreamProtocol,
+)
+from ..base.protocols import (
+    SyncStreamHandler,
+    AsyncStreamHandler,
+)
+
+P = ParamSpec("P")
+
+
+def _process_messages(span: Span, kwargs: dict[str, Any]) -> None:
+    """Process and record input messages."""
+    for message in kwargs.get("messages", []):
+        _utils.set_message_event(span, message)
+
+
+def _create_stream_wrapper(
+    span: Span, stream: StreamProtocol[CompletionEvent]
+) -> StreamWrapper[CompletionEvent, _utils.MistralMetadata]:
+    """Create Mistral-specific stream wrapper."""
+    return StreamWrapper(
+        span=span,
+        stream=stream,
+        metadata=_utils.MistralMetadata(),
+        chunk_handler=_utils.MistralChunkHandler(),
+        cleanup_handler=_utils.default_mistral_cleanup,
+    )
+
+
+async def _create_async_stream_wrapper(
+    span: Span, stream: AsyncStreamProtocol[CompletionEvent]
+) -> AsyncStreamWrapper[CompletionEvent, _utils.MistralMetadata]:
+    """Create Mistral-specific async stream wrapper."""
+    return AsyncStreamWrapper(
+        span=span,
+        stream=stream,
+        metadata=_utils.MistralMetadata(),
+        chunk_handler=_utils.MistralChunkHandler(),
+        cleanup_handler=_utils.default_mistral_cleanup,
+    )
+
+
+def chat_complete_patch_factory(
+    tracer: Tracer,
+) -> SyncStreamHandler[P, CompletionEvent, _utils.MistralMetadata, Mistral]:
+    """Returns a patch factory for sync chat complete method."""
+    return create_sync_wrapper(
+        tracer=tracer,
+        get_span_attributes=_utils.get_llm_request_attributes,
+        process_messages=_process_messages,
+        process_response=_utils.set_response_attributes,
+        create_stream_wrapper=_create_stream_wrapper,
+        handle_stream=True,
+    )
+
+
+def chat_complete_async_patch_factory(
+    tracer: Tracer,
+) -> AsyncStreamHandler[P, CompletionEvent, _utils.MistralMetadata, Mistral]:
+    """Returns a patch factory for async chat complete method."""
+    return create_async_wrapper(
+        tracer=tracer,
+        get_span_attributes=_utils.get_llm_request_attributes,
+        process_messages=_process_messages,
+        process_response=_utils.set_response_attributes,
+        create_async_stream_wrapper=_create_async_stream_wrapper,
+        handle_stream=True,
+    )

--- a/sdks/python/src/lilypad/_internal/otel/mistral/_utils.py
+++ b/sdks/python/src/lilypad/_internal/otel/mistral/_utils.py
@@ -1,0 +1,248 @@
+"""Utility functions for Mistral OpenTelemetry instrumentation.
+
+This module provides helper functions for extracting and formatting Mistral API
+response data for telemetry purposes.
+"""
+
+import json
+from typing import Any, Protocol
+
+from opentelemetry.trace import Span
+from opentelemetry.util.types import AttributeValue
+from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
+
+from ..utils import (
+    BaseMetadata,
+    ChoiceBuffer,
+    ChunkHandler,
+    set_server_address_and_port,
+)
+from ...utils import json_dumps
+
+from mistralai import Mistral
+from mistralai.models import (
+    ChatCompletionResponse,
+    CompletionEvent,
+    CompletionChunk,
+    ChatCompletionChoice,
+    CompletionResponseStreamChoice,
+    UsageInfo,
+    AssistantMessage,
+    DeltaMessage,
+)
+
+
+class MistralMetadata(BaseMetadata, total=False):
+    """Mistral-specific metadata extending BaseMetadata."""
+
+    finish_reasons: list[str]
+
+
+class MistralMessageProtocol(Protocol):
+    """Protocol for Mistral chat messages."""
+
+    role: str
+    content: str | None
+
+
+class MistralChoiceProtocol(Protocol):
+    """Protocol for Mistral chat choices."""
+
+    index: int
+    message: AssistantMessage
+    finish_reason: str | None
+
+
+class MistralCompletionProtocol(Protocol):
+    """Protocol for Mistral chat completions."""
+
+    id: str
+    model: str
+    choices: list[ChatCompletionChoice]
+    usage: UsageInfo | None
+
+
+class MistralStreamChoiceProtocol(Protocol):
+    """Protocol for Mistral streaming choices."""
+
+    index: int
+    delta: DeltaMessage
+    finish_reason: str | None
+
+
+class MistralStreamChunkProtocol(Protocol):
+    """Protocol for Mistral streaming chunks."""
+
+    id: str
+    model: str
+    choices: list[CompletionResponseStreamChoice]
+    usage: UsageInfo | None
+
+
+class MistralChunkHandler(ChunkHandler[CompletionEvent, MistralMetadata]):
+    """Handler for processing Mistral streaming chunks."""
+
+    def extract_metadata(
+        self, chunk: CompletionEvent, metadata: MistralMetadata
+    ) -> None:
+        """Extract metadata from a streaming chunk and update the metadata dictionary."""
+        data: CompletionChunk = chunk.data
+        if not metadata.get("response_model") and data.model:
+            metadata["response_model"] = data.model
+        if not metadata.get("response_id") and data.id:
+            metadata["response_id"] = data.id
+        if usage := data.usage:
+            if completion_tokens := usage.completion_tokens:
+                metadata["completion_tokens"] = completion_tokens
+            if prompt_tokens := usage.prompt_tokens:
+                metadata["prompt_tokens"] = prompt_tokens
+
+    def process_chunk(
+        self, chunk: CompletionEvent, buffers: list[ChoiceBuffer]
+    ) -> None:
+        """Process a streaming chunk and update the choice buffers with content."""
+        data: CompletionChunk = chunk.data
+        for choice in data.choices:
+            while len(buffers) <= choice.index:
+                buffers.append(ChoiceBuffer(len(buffers)))
+
+            if finish_reason := choice.finish_reason:
+                buffers[choice.index].finish_reason = str(finish_reason)
+
+            if delta := choice.delta:
+                if delta.content is not None and isinstance(delta.content, str):
+                    buffers[choice.index].append_text_content(delta.content)
+
+
+def default_mistral_cleanup(
+    span: Span, metadata: MistralMetadata, buffers: list[ChoiceBuffer]
+) -> None:
+    """Set final span attributes and events from accumulated metadata and buffers."""
+    attributes: dict[str, AttributeValue] = {}
+    if response_model := metadata.get("response_model"):
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_MODEL] = response_model
+    if response_id := metadata.get("response_id"):
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_ID] = response_id
+    if prompt_tokens := metadata.get("prompt_tokens"):
+        attributes[gen_ai_attributes.GEN_AI_USAGE_INPUT_TOKENS] = prompt_tokens
+    if completion_tokens := metadata.get("completion_tokens"):
+        attributes[gen_ai_attributes.GEN_AI_USAGE_OUTPUT_TOKENS] = completion_tokens
+
+    if finish_reasons := tuple(
+        str(buffer.finish_reason)
+        for buffer in buffers
+        if buffer.finish_reason is not None
+    ):
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_FINISH_REASONS] = finish_reasons
+
+    span.set_attributes(attributes)
+    for index, choice in enumerate(buffers):
+        message: dict[str, Any] = {"role": "assistant"}
+        if text_content := choice.text_content:
+            message["content"] = "".join(text_content)
+
+        event_attributes: dict[str, AttributeValue] = {
+            gen_ai_attributes.GEN_AI_SYSTEM: "mistral",
+            "index": index,
+            "finish_reason": str(choice.finish_reason)
+            if choice.finish_reason
+            else "none",
+            "message": json.dumps(message),
+        }
+        span.add_event("gen_ai.choice", attributes=event_attributes)
+
+
+def set_message_event(span: Span, message: dict[str, Any]) -> None:
+    """Add a message event to the span with appropriate attributes."""
+    attributes: dict[str, AttributeValue] = {gen_ai_attributes.GEN_AI_SYSTEM: "mistral"}
+
+    role = message.get("role", "")
+    content = message.get("content")
+
+    if content is not None:
+        if not isinstance(content, str):
+            content = json_dumps(content)
+        attributes["content"] = content
+
+    span.add_event(
+        f"gen_ai.{role}.message",
+        attributes=attributes,
+    )
+
+
+def get_choice_event(choice: ChatCompletionChoice) -> dict[str, AttributeValue]:
+    """Extract event attributes from a choice object."""
+    attributes: dict[str, AttributeValue] = {gen_ai_attributes.GEN_AI_SYSTEM: "mistral"}
+
+    message_dict: dict[str, Any] = {"role": choice.message.role}
+    if content := choice.message.content:
+        message_dict["content"] = content
+
+    attributes["message"] = json.dumps(message_dict)
+    attributes["index"] = choice.index
+    attributes["finish_reason"] = (
+        str(choice.finish_reason) if choice.finish_reason else "none"
+    )
+    return attributes
+
+
+def set_response_attributes(span: Span, response: ChatCompletionResponse) -> None:
+    """Set span attributes from non-streaming response."""
+    attributes: dict[str, AttributeValue] = {}
+
+    if model := response.model:
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_MODEL] = model
+
+    if choices := response.choices:
+        finish_reasons = []
+        for choice in choices:
+            choice_attributes = get_choice_event(choice)
+            span.add_event(
+                "gen_ai.choice",
+                attributes=choice_attributes,
+            )
+            if finish_reason := choice.finish_reason:
+                finish_reasons.append(str(finish_reason))
+        if finish_reasons:
+            attributes[gen_ai_attributes.GEN_AI_RESPONSE_FINISH_REASONS] = tuple(
+                finish_reasons
+            )
+
+    if response_id := response.id:
+        attributes[gen_ai_attributes.GEN_AI_RESPONSE_ID] = response_id
+
+    if usage := response.usage:
+        if prompt_tokens := usage.prompt_tokens:
+            attributes[gen_ai_attributes.GEN_AI_USAGE_INPUT_TOKENS] = prompt_tokens
+        if completion_tokens := usage.completion_tokens:
+            attributes[gen_ai_attributes.GEN_AI_USAGE_OUTPUT_TOKENS] = completion_tokens
+
+    span.set_attributes(attributes)
+
+
+def get_llm_request_attributes(
+    kwargs: dict[str, Any],
+    client: Mistral,
+    operation_name: str = gen_ai_attributes.GenAiOperationNameValues.CHAT.value,
+) -> dict[str, AttributeValue]:
+    """Extract span attributes from request kwargs and client."""
+    attributes: dict[str, AttributeValue] = {
+        gen_ai_attributes.GEN_AI_OPERATION_NAME: operation_name,
+        gen_ai_attributes.GEN_AI_SYSTEM: "mistral",
+    }
+
+    if model := kwargs.get("model"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_MODEL] = model
+
+    if "temperature" in kwargs:
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_TEMPERATURE] = kwargs["temperature"]
+
+    if max_tokens := kwargs.get("max_tokens"):
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_MAX_TOKENS] = max_tokens
+
+    if "top_p" in kwargs:
+        attributes[gen_ai_attributes.GEN_AI_REQUEST_TOP_P] = kwargs["top_p"]
+
+    set_server_address_and_port(client, attributes)
+
+    return attributes

--- a/sdks/python/src/lilypad/_internal/otel/mistral/instrument.py
+++ b/sdks/python/src/lilypad/_internal/otel/mistral/instrument.py
@@ -1,0 +1,69 @@
+"""Mistral client instrumentation for OpenTelemetry tracing.
+
+This module provides instrumentation for the Mistral Python client to automatically
+create OpenTelemetry spans for API calls.
+"""
+
+import logging
+from importlib.metadata import PackageNotFoundError, version
+
+from wrapt import FunctionWrapper
+from opentelemetry.trace import get_tracer
+from opentelemetry.semconv.schemas import Schemas
+
+from . import _patch
+
+from mistralai import Mistral
+
+logger = logging.getLogger(__name__)
+
+
+def instrument_mistral(
+    client: Mistral,
+) -> None:
+    """
+    Instrument the Mistral client with OpenTelemetry tracing.
+
+    Args:
+        client: The Mistral instance to instrument.
+    """
+    # TODO: Add support for chat.stream and chat.stream_async methods after protocol refactoring
+    if hasattr(client, "_lilypad_instrumented"):
+        logger.debug(f"{type(client).__name__} already instrumented, skipping")
+        return
+
+    try:
+        lilypad_version = version("lilypad-sdk")
+    except PackageNotFoundError:
+        lilypad_version = "unknown"
+        logger.debug("Could not determine lilypad-sdk version")
+
+    tracer = get_tracer(
+        __name__,
+        lilypad_version,
+        schema_url=Schemas.V1_28_0.value,
+    )
+
+    # Wrap synchronous complete method
+    try:
+        client.chat.complete = FunctionWrapper(
+            client.chat.complete,
+            _patch.chat_complete_patch_factory(tracer),
+        )
+        logger.debug("Successfully wrapped Mistral.chat.complete")
+    except Exception as e:
+        logger.warning(f"Failed to wrap Mistral.chat.complete: {type(e).__name__}: {e}")
+
+    # Wrap asynchronous complete_async method
+    try:
+        client.chat.complete_async = FunctionWrapper(
+            client.chat.complete_async,
+            _patch.chat_complete_async_patch_factory(tracer),
+        )
+        logger.debug("Successfully wrapped Mistral.chat.complete_async")
+    except Exception as e:
+        logger.warning(
+            f"Failed to wrap Mistral.chat.complete_async: {type(e).__name__}: {e}"
+        )
+
+    client._lilypad_instrumented = True  # pyright: ignore[reportAttributeAccessIssue]

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -429,6 +429,15 @@ wheels = [
 ]
 
 [[package]]
+name = "eval-type-backport"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/ea/8b0ac4469d4c347c6a385ff09dc3c048c2d021696664e26c7ee6791631b5/eval_type_backport-0.2.2.tar.gz", hash = "sha256:f0576b4cf01ebb5bd358d02314d31846af5e07678387486e2c798af0e7d849c1", size = 9079, upload-time = "2024-12-21T20:09:46.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/31/55cd413eaccd39125368be33c46de24a1f639f2e12349b0361b4678f3915/eval_type_backport-0.2.2-py3-none-any.whl", hash = "sha256:cb6ad7c393517f476f96d456d0412ea80f0a8cf96f6892834cd9340149111b0a", size = 5830, upload-time = "2024-12-21T20:09:44.175Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -678,6 +687,15 @@ wheels = [
 ]
 
 [[package]]
+name = "invoke"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/42/127e6d792884ab860defc3f4d80a8f9812e48ace584ffc5a346de58cdc6c/invoke-2.2.0.tar.gz", hash = "sha256:ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5", size = 299835, upload-time = "2023-07-12T18:05:17.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/66/7f8c48009c72d73bc6bbe6eb87ac838d6a526146f7dab14af671121eb379/invoke-2.2.0-py3-none-any.whl", hash = "sha256:6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820", size = 160274, upload-time = "2023-07-12T18:05:16.294Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -785,6 +803,9 @@ google = [
     { name = "pillow" },
     { name = "proto-plus" },
 ]
+mistral = [
+    { name = "mistralai" },
+]
 openai = [
     { name = "openai" },
 ]
@@ -800,6 +821,7 @@ examples = [
     { name = "anthropic" },
     { name = "azure-ai-inference" },
     { name = "google-genai" },
+    { name = "mistralai" },
     { name = "openai" },
 ]
 test = [
@@ -819,6 +841,7 @@ requires-dist = [
     { name = "azure-ai-inference", marker = "extra == 'azure'", specifier = ">=1.0.0b9" },
     { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.30.0,<2" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mistralai", marker = "extra == 'mistral'", specifier = ">=1.0.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.98.0" },
     { name = "opentelemetry-api", specifier = ">=1.36.0" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.57b0" },
@@ -829,7 +852,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "wrapt", specifier = ">=1.17.2" },
 ]
-provides-extras = ["openai", "anthropic", "google", "azure"]
+provides-extras = ["openai", "anthropic", "google", "azure", "mistral"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -842,6 +865,7 @@ examples = [
     { name = "anthropic", specifier = ">=0.63.0" },
     { name = "azure-ai-inference", specifier = ">=1.0.0b9" },
     { name = "google-genai", specifier = ">=1.7.0,<2" },
+    { name = "mistralai", specifier = ">=1.0.0" },
     { name = "openai", specifier = ">=1.98.0" },
 ]
 test = [
@@ -873,6 +897,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mistralai"
+version = "1.9.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "eval-type-backport" },
+    { name = "httpx" },
+    { name = "invoke" },
+    { name = "pydantic" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/0f/c9f39c71ff5f59a3cfa98836ccb8107e5c1724916f2f1ec57a5911f28cc9/mistralai-1.9.6.tar.gz", hash = "sha256:0ebc71812abbbc47cefc019c6a850f81763fa0ab21bd984b8feaccfd09e285b1", size = 197412, upload-time = "2025-08-17T19:04:29.387Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/a8/ccfe0592c3f5f8b5c730645d7c032af936148f0c5f4633e7f5382cfc14bb/mistralai-1.9.6-py3-none-any.whl", hash = "sha256:682dcb3561154450496172619b6148bd208cc0a9f8eb81c6def218b8ed127eec", size = 425748, upload-time = "2025-08-17T19:04:27.929Z" },
 ]
 
 [[package]]
@@ -1555,6 +1597,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/60/104c619483c1a42775d3f8b27293f1ecfc0728014874d065e68cb9702d49/pytest-vcr-1.0.2.tar.gz", hash = "sha256:23ee51b75abbcc43d926272773aae4f39f93aceb75ed56852d0bf618f92e1896", size = 3810, upload-time = "2019-04-26T19:04:00.806Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/d3/ff520d11e6ee400602711d1ece8168dcfc5b6d8146fb7db4244a6ad6a9c3/pytest_vcr-1.0.2-py2.py3-none-any.whl", hash = "sha256:2f316e0539399bea0296e8b8401145c62b6f85e9066af7e57b6151481b0d6d9c", size = 4137, upload-time = "2019-04-26T19:03:57.034Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry instrumentation support for the Mistral AI client.

### What changed?

- Added instrumentation for the Mistral AI Python client to capture telemetry data
- Implemented wrappers for both synchronous and asynchronous chat completion methods
- Created utility functions to extract and format Mistral API response data
- Added a new example demonstrating how to use the Mistral instrumentation with console output
- Updated dependencies to include Mistral as an optional dependency

### How to test?

1. Install the SDK with Mistral support:
   ```
   pip install "lilypad-sdk[mistral]"
   ```

2. Run the example script after setting your Mistral API key:
   ```
   export MISTRAL_API_KEY=your_api_key
   python sdks/python/examples/instrument_mistral_with_console.py
   ```

3. Verify that OpenTelemetry spans are printed to the console, showing the request and response details from the Mistral API call.

### Why make this change?

This change extends Lilypad's observability capabilities to include Mistral AI's LLM services, allowing users to trace and monitor their Mistral API calls alongside other supported LLM providers. This provides a consistent instrumentation approach across multiple AI service providers, making it easier to debug, monitor, and analyze application performance and behavior when using Mistral's models.