### PR TITLE
test: Add unit tests for Mistral OpenTelemetry in Lilypad v1

### DIFF
--- a/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_async_completion_simple.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_async_completion_simple.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: '{"model":"mistral-small-latest","messages":[{"content":"Hello, say ''Hi''
+      back to me","role":"user"}],"max_tokens":50,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '131'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+      user-agent:
+      - mistral-client-python/1.9.6
+    method: POST
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOQU7DMBCF4auYt3ZRk9ZN8YZtOQNC1dSZEhfHE8VTQVXlApyAHVfkCCgL6Pbp
+        l953RWzhcXSuajbVsVluad2EzUNYuro5uJbrmuq2gkUYmZRb+Kpxzm1XbuUsemk5waOPRUdKi9JT
+        SotEykVhcS70yvBXDKP0g+5V3jgX+Kq2UFFK/0u9sQjSD4k1Sr6F68lCDicOCo/Qkd7fqhnVSQxc
+        4J+viLnlD/ilxTHmWLr9yFQkw6OoDLDoufx5RkkMDyolFqU8W1Uk7QOlVODzOaXZk5XzfLyLRjse
+        +c78fH99mp28m0DZPJmO02AucjYqLV0eMU0v0y8AAAD//wMA/a1VBlMBAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Aug 2025 06:05:35 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      mistral-correlation-id:
+      - 0198c0ee-d9f3-74dd-b8ae-ee66b4a9550c
+      x-envoy-upstream-service-time:
+      - '152'
+      x-kong-proxy-latency:
+      - '7'
+      x-kong-request-id:
+      - 0198c0ee-d9f3-74dd-b8ae-ee66b4a9550c
+      x-kong-upstream-latency:
+      - '152'
+      x-ratelimit-limit-req-10-second:
+      - '60'
+      x-ratelimit-limit-tokens-minute:
+      - '2000000'
+      x-ratelimit-limit-tokens-month:
+      - '10000000000'
+      x-ratelimit-remaining-req-10-second:
+      - '55'
+      x-ratelimit-remaining-tokens-minute:
+      - '1999835'
+      x-ratelimit-remaining-tokens-month:
+      - '9999996919'
+      x-ratelimit-tokens-query-cost:
+      - '26'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_async_completion_with_temperature.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_async_completion_with_temperature.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: '{"model":"mistral-small-latest","messages":[{"content":"Write the word
+      ''test''","role":"user"}],"temperature":0.0,"max_tokens":10,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '144'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+      user-agent:
+      - mistral-client-python/1.9.6
+    method: POST
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TPUW7CMBAE0KtE822qAEkgPkHvUCrkxgtxu/FG3kW0Qrl7lY+W39FI8+aBFOFx
+        2NWHtgtd28TYXCKFpqtjvwvx2FBdUw+HoVAwivDbQ9u2x3277xwmicTwmJJaCbzRKTBvOBipweGm
+        4UrwD8xFptnOJl+UFb53MLHA/8G2dxhkmpksSX7G9eIgH580GDyGMdjLs7WaRkkDKfzbAylH+oav
+        HS4pJx3PhYJKhgdTvtoIh4n0D1SECR5BNamFvGJNhM9DYFb4fGNeRdkor9OvVKhKWtlI1V1KrE5Y
+        L55Q3Usyo1xdpFQ/csOyvC+/AAAA//8DAA8qhhFVAQAA
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Aug 2025 06:05:36 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      mistral-correlation-id:
+      - 0198c0ee-dbf4-7bd4-a5b9-05a1afd51e8e
+      x-envoy-upstream-service-time:
+      - '106'
+      x-kong-proxy-latency:
+      - '6'
+      x-kong-request-id:
+      - 0198c0ee-dbf4-7bd4-a5b9-05a1afd51e8e
+      x-kong-upstream-latency:
+      - '106'
+      x-ratelimit-limit-req-10-second:
+      - '60'
+      x-ratelimit-limit-tokens-minute:
+      - '2000000'
+      x-ratelimit-limit-tokens-month:
+      - '10000000000'
+      x-ratelimit-remaining-req-10-second:
+      - '54'
+      x-ratelimit-remaining-tokens-minute:
+      - '1999816'
+      x-ratelimit-remaining-tokens-month:
+      - '9999996900'
+      x-ratelimit-tokens-query-cost:
+      - '19'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_async_error_handling.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_async_error_handling.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: '{"model":"invalid-model-xyz","messages":[{"content":"Hello","role":"user"}],"max_tokens":50,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '107'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+      user-agent:
+      - mistral-client-python/1.9.6
+    method: POST
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    body:
+      string: '{"object":"error","message":"Invalid model: invalid-model-xyz","type":"invalid_model","param":null,"code":"1500"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Aug 2025 06:05:37 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      mistral-correlation-id:
+      - 0198c0ee-e006-7f5b-ba9f-6c1e5ad15d91
+      x-envoy-upstream-service-time:
+      - '44'
+      x-kong-proxy-latency:
+      - '9'
+      x-kong-request-id:
+      - 0198c0ee-e006-7f5b-ba9f-6c1e5ad15d91
+      x-kong-upstream-latency:
+      - '45'
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_sync_completion_simple.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_sync_completion_simple.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: '{"model":"mistral-small-latest","messages":[{"content":"Hello, say ''Hi''
+      back to me","role":"user"}],"max_tokens":50,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '131'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+      user-agent:
+      - mistral-client-python/1.9.6
+    method: POST
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOQU7DMBCF4auYt3ZRnTZN4w3bcgaEqqkzJQbHE8VTQVXlApyAHVfkCKgL6Pbp
+        l953Qezg0brQVU1zoEOo1i50rXPLZttWrmlaOm5WsAgTk3IH75q6rrereuUsBuk4wWOIRSdKizJQ
+        SotEykVhcSr0wvAXjJMMo+5V3jgXeFdZqCil/6XaWAQZxsQaJd/C9Wwhh1cOCo/Qk97fqiuqlxi4
+        wD9dEHPHH/BLi2PMsfT7ialIhkdRGWExcPnzTJIYHlRKLEr5alWRtA+UUoHPp5Sunqycr8e7aLTn
+        ie/Mz/fXp9nJuwmUzaPpOY3mLCej0tH5AfP8PP8CAAD//wMAws5YV1MBAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Aug 2025 06:05:32 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      mistral-correlation-id:
+      - 0198c0ee-cb4e-7378-ba5f-63efe32ea97a
+      x-envoy-upstream-service-time:
+      - '143'
+      x-kong-proxy-latency:
+      - '9'
+      x-kong-request-id:
+      - 0198c0ee-cb4e-7378-ba5f-63efe32ea97a
+      x-kong-upstream-latency:
+      - '143'
+      x-ratelimit-limit-req-10-second:
+      - '60'
+      x-ratelimit-limit-tokens-minute:
+      - '2000000'
+      x-ratelimit-limit-tokens-month:
+      - '10000000000'
+      x-ratelimit-remaining-req-10-second:
+      - '59'
+      x-ratelimit-remaining-tokens-minute:
+      - '1999974'
+      x-ratelimit-remaining-tokens-month:
+      - '9999997058'
+      x-ratelimit-tokens-query-cost:
+      - '26'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_sync_completion_with_multiple_messages.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_sync_completion_with_multiple_messages.yaml
@@ -1,0 +1,80 @@
+interactions:
+- request:
+    body: '{"model":"mistral-small-latest","messages":[{"content":"My name is Alice","role":"user"},{"content":"Nice
+      to meet you, Alice!","prefix":false,"role":"assistant"},{"content":"What''s
+      my name?","role":"user"}],"max_tokens":50,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '238'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+      user-agent:
+      - mistral-client-python/1.9.6
+    method: POST
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0SQQU4CQRBFr9LUSieNAYYB7J2HcGHEkJqegmns7iJTNUFDSFy7duHOu3kCj2Bm
+        IW5fXvJf/glCAw6mzRRxufW0pXo+p7rG2aS+XflyNV1MFjMPFnxHqNSAmy6rqlqVVTm3kLihCA5S
+        EO0wjiVhjOOISqJgoRfcEbgTHDpOB90oP1MWcLOZBWXFeCFVZcFzOkTSwPmCy/Jsges9eQUHvkW9
+        +beGqJaDJwH3eIKQG3oBN7GwDTlIu+kIhTM4EOUDWEgkfz0dRwIHKBJEMQ+tyhw3HmMUcLmPcejJ
+        SnkYfuC+MxkTmSCmKO5i8FQU328fr9ybfS9qlGNjEo3Mz9fn+zqv89V9jiRiBuNIHZnhkpB3JpE1
+        IZtjG3xrPAo5U+xYfYuj4hrO56fzLwAAAP//AwC1C8iglAEAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Aug 2025 06:05:35 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      mistral-correlation-id:
+      - 0198c0ee-d758-71d7-b623-2f9adeccbe5c
+      x-envoy-upstream-service-time:
+      - '273'
+      x-kong-proxy-latency:
+      - '6'
+      x-kong-request-id:
+      - 0198c0ee-d758-71d7-b623-2f9adeccbe5c
+      x-kong-upstream-latency:
+      - '274'
+      x-ratelimit-limit-req-10-second:
+      - '60'
+      x-ratelimit-limit-tokens-minute:
+      - '2000000'
+      x-ratelimit-limit-tokens-month:
+      - '10000000000'
+      x-ratelimit-remaining-req-10-second:
+      - '56'
+      x-ratelimit-remaining-tokens-minute:
+      - '1999861'
+      x-ratelimit-remaining-tokens-month:
+      - '9999996945'
+      x-ratelimit-tokens-query-cost:
+      - '55'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_sync_completion_with_system_message.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_sync_completion_with_system_message.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: '{"model":"mistral-small-latest","messages":[{"content":"You are a helpful
+      assistant","role":"system"},{"content":"Count from 1 to 3","role":"user"}],"temperature":0.7,"max_tokens":50,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '198'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+      user-agent:
+      - mistral-client-python/1.9.6
+    method: POST
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0TOwW6DMBAE0F9Bc3YqAiEB/0aPpYqM2QQ3xou8i9Qq4t8rDm2uo9HMeyKMsDj7
+        41i2vjsNN39qztUw+PrSXcrT0HUtnVsY+ExOaYQ9Xpqmaeumrg1mHinCYg6i2cWDzC7GQ3RKojBY
+        xd0J9okl87zoVflBSfYJA2V18T+pOgPP8xJJA6dXsdoMePgir7Dwk9O3V2tHTRw8CezHEyGN9A1b
+        GtxCCjJdMznhBAtRXmAwk/x5MkeChRMJoi7tVmWOV+9iFNi0xrh7klLaj9/XTKaYKFPxw2txZ9un
+        Ph37VPWpxrZ9br8AAAD//wMApc0HjEgBAAA=
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Aug 2025 06:05:33 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      mistral-correlation-id:
+      - 0198c0ee-cfe7-7cbd-bd5c-94cc3914f282
+      x-envoy-upstream-service-time:
+      - '149'
+      x-kong-proxy-latency:
+      - '7'
+      x-kong-request-id:
+      - 0198c0ee-cfe7-7cbd-bd5c-94cc3914f282
+      x-kong-upstream-latency:
+      - '150'
+      x-ratelimit-limit-req-10-second:
+      - '60'
+      x-ratelimit-limit-tokens-minute:
+      - '2000000'
+      x-ratelimit-limit-tokens-month:
+      - '10000000000'
+      x-ratelimit-remaining-req-10-second:
+      - '58'
+      x-ratelimit-remaining-tokens-minute:
+      - '1999945'
+      x-ratelimit-remaining-tokens-month:
+      - '9999997029'
+      x-ratelimit-tokens-query-cost:
+      - '29'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_sync_completion_with_top_p.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_sync_completion_with_top_p.yaml
@@ -1,0 +1,78 @@
+interactions:
+- request:
+    body: '{"model":"mistral-small-latest","messages":[{"content":"Write the number
+      42","role":"user"}],"top_p":0.9,"max_tokens":20,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '136'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+      user-agent:
+      - mistral-client-python/1.9.6
+    method: POST
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA0SOQU7DMBBFrxL9ZeRWaVKrxHsQB2BHUeUk08bgjCPPVAVVuTvKArp970v/3REG
+        OJxt723b7K2th721re9oqOywOze+ag5dDYM+k1ca4HYHa+1TY5vGYEoDRThMQTT7uJHJx7iJXkkU
+        BlfxF4K7Y85pmvWk6YtY4FoDTerjP6hbgz5NcyQNiR+4WgxS90m9wqEfvW4fq7VpTKEngXu/I/BA
+        33CVwTlwkPGUyUtiOETii44wmEj+gnKKBAcvEkQ9r7GaUjz1PkaB42uMaxEr8Xr9NlLB16mjXJTl
+        vi7LIkhxy0GVuPDijnzksnxJWX82ekur5+KZLzHIuF3lK2UqgmJZPpZfAAAA//8DADUx7bt0AQAA
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Aug 2025 06:05:34 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      mistral-correlation-id:
+      - 0198c0ee-d265-7e35-bc35-17b647594063
+      x-envoy-upstream-service-time:
+      - '312'
+      x-kong-proxy-latency:
+      - '12'
+      x-kong-request-id:
+      - 0198c0ee-d265-7e35-bc35-17b647594063
+      x-kong-upstream-latency:
+      - '313'
+      x-ratelimit-limit-req-10-second:
+      - '60'
+      x-ratelimit-limit-tokens-minute:
+      - '2000000'
+      x-ratelimit-limit-tokens-month:
+      - '10000000000'
+      x-ratelimit-remaining-req-10-second:
+      - '57'
+      x-ratelimit-remaining-tokens-minute:
+      - '1999916'
+      x-ratelimit-remaining-tokens-month:
+      - '9999997000'
+      x-ratelimit-tokens-query-cost:
+      - '29'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_sync_error_handling.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/mistral/cassettes/test_sync_error_handling.yaml
@@ -1,0 +1,56 @@
+interactions:
+- request:
+    body: '{"model":"invalid-model-xyz","messages":[{"content":"Hello","role":"user"}],"max_tokens":50,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '107'
+      content-type:
+      - application/json
+      host:
+      - api.mistral.ai
+      user-agent:
+      - mistral-client-python/1.9.6
+    method: POST
+    uri: https://api.mistral.ai/v1/chat/completions
+  response:
+    body:
+      string: '{"object":"error","message":"Invalid model: invalid-model-xyz","type":"invalid_model","param":null,"code":"1500"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '113'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Aug 2025 06:05:36 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      access-control-allow-origin:
+      - '*'
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      mistral-correlation-id:
+      - 0198c0ee-de64-7ef2-a15b-d70013a674df
+      x-envoy-upstream-service-time:
+      - '44'
+      x-kong-proxy-latency:
+      - '7'
+      x-kong-request-id:
+      - 0198c0ee-de64-7ef2-a15b-d70013a674df
+      x-kong-upstream-latency:
+      - '45'
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/mistral/test_instrument.py
+++ b/sdks/python/tests/lilypad/_internal/otel/mistral/test_instrument.py
@@ -1,0 +1,427 @@
+import os
+from unittest.mock import Mock, patch
+from importlib.metadata import PackageNotFoundError
+
+import pytest
+from wrapt import FunctionWrapper
+from dotenv import load_dotenv
+from mistralai import Mistral, SDKError
+from mistralai.models import (
+    ChatCompletionResponse,
+)
+from inline_snapshot import snapshot
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from lilypad._internal.otel.mistral.instrument import instrument_mistral
+
+from ..test_utils import extract_span_data
+
+
+@pytest.fixture
+def mistral_api_key() -> str:
+    load_dotenv()
+    api_key = os.getenv("MISTRAL_API_KEY", "test-api-key")
+    return api_key
+
+
+@pytest.fixture
+def client(mistral_api_key: str) -> Mistral:
+    client = Mistral(api_key=mistral_api_key)
+    instrument_mistral(client)
+    return client
+
+
+@pytest.fixture
+def async_client(mistral_api_key: str) -> Mistral:
+    client = Mistral(api_key=mistral_api_key)
+    instrument_mistral(client)
+    return client
+
+
+@pytest.mark.vcr()
+def test_sync_completion_simple(
+    client: Mistral, span_exporter: InMemorySpanExporter
+) -> None:
+    response = client.chat.complete(
+        model="mistral-small-latest",
+        messages=[{"role": "user", "content": "Hello, say 'Hi' back to me"}],
+        max_tokens=50,
+    )
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert response.choices
+    assert response.choices[0].message.content
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat mistral-small-latest",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.system": "mistral",
+                "gen_ai.request.model": "mistral-small-latest",
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.response.model": "mistral-small-latest",
+                "gen_ai.response.finish_reasons": ("stop",),
+                "gen_ai.response.id": "91cd277babc241cd911078921779af63",
+                "gen_ai.usage.input_tokens": 12,
+                "gen_ai.usage.output_tokens": 14,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "content": "Hello, say 'Hi' back to me",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "message": '{"role": "assistant", "content": "Hi there! \\ud83d\\ude0a How can I help you today?"}',
+                        "index": 0,
+                        "finish_reason": "stop",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_completion_with_system_message(
+    client: Mistral, span_exporter: InMemorySpanExporter
+) -> None:
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant"},
+        {"role": "user", "content": "Count from 1 to 3"},
+    ]
+
+    response = client.chat.complete(
+        model="mistral-small-latest",
+        messages=messages,
+        max_tokens=50,
+        temperature=0.7,
+    )
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert response.choices
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat mistral-small-latest",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.system": "mistral",
+                "gen_ai.request.model": "mistral-small-latest",
+                "gen_ai.request.temperature": 0.7,
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.response.model": "mistral-small-latest",
+                "gen_ai.response.finish_reasons": ("stop",),
+                "gen_ai.response.id": "6c1d08c94bfc4562bbc379704b998e68",
+                "gen_ai.usage.input_tokens": 17,
+                "gen_ai.usage.output_tokens": 12,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.system.message",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "content": "You are a helpful assistant",
+                    },
+                },
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "content": "Count from 1 to 3",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "message": '{"role": "assistant", "content": "Sure, here you go:\\n\\n1\\n2\\n3"}',
+                        "index": 0,
+                        "finish_reason": "stop",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_sync_completion_with_top_p(
+    client: Mistral, span_exporter: InMemorySpanExporter
+) -> None:
+    response = client.chat.complete(
+        model="mistral-small-latest",
+        messages=[{"role": "user", "content": "Write the number 42"}],
+        max_tokens=20,
+        top_p=0.9,
+    )
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert response.choices
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_data = extract_span_data(spans[0])
+    assert span_data["attributes"]["gen_ai.request.top_p"] == 0.9
+    assert span_data["attributes"]["gen_ai.request.max_tokens"] == 20
+
+
+@pytest.mark.vcr()
+def test_sync_completion_with_multiple_messages(
+    client: Mistral, span_exporter: InMemorySpanExporter
+) -> None:
+    messages = [
+        {"role": "user", "content": "My name is Alice"},
+        {"role": "assistant", "content": "Nice to meet you, Alice!"},
+        {"role": "user", "content": "What's my name?"},
+    ]
+
+    response = client.chat.complete(
+        model="mistral-small-latest",
+        messages=messages,
+        max_tokens=50,
+    )
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert "Alice" in response.choices[0].message.content
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat mistral-small-latest",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.system": "mistral",
+                "gen_ai.request.model": "mistral-small-latest",
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.response.model": "mistral-small-latest",
+                "gen_ai.response.finish_reasons": ("stop",),
+                "gen_ai.response.id": "1d1aa7fcefeb44ebba20b98c3816062c",
+                "gen_ai.usage.input_tokens": 22,
+                "gen_ai.usage.output_tokens": 33,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "content": "My name is Alice",
+                    },
+                },
+                {
+                    "name": "gen_ai.assistant.message",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "content": "Nice to meet you, Alice!",
+                    },
+                },
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "content": "What's my name?",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "message": '{"role": "assistant", "content": "Your name is **Alice**\\u2014you just told me! \\ud83d\\ude0a\\n\\n(Unless you were testing me, in which case: *gotcha!*)"}',
+                        "index": 0,
+                        "finish_reason": "stop",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_async_completion_simple(
+    async_client: Mistral, span_exporter: InMemorySpanExporter
+) -> None:
+    response = await async_client.chat.complete_async(
+        model="mistral-small-latest",
+        messages=[{"role": "user", "content": "Hello, say 'Hi' back to me"}],
+        max_tokens=50,
+    )
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert response.choices
+    assert response.choices[0].message.content
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert extract_span_data(spans[0]) == snapshot(
+        {
+            "name": "chat mistral-small-latest",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.system": "mistral",
+                "gen_ai.request.model": "mistral-small-latest",
+                "gen_ai.request.max_tokens": 50,
+                "gen_ai.response.model": "mistral-small-latest",
+                "gen_ai.response.finish_reasons": ("stop",),
+                "gen_ai.response.id": "f551761f708a47c69c0527b5de22a2d1",
+                "gen_ai.usage.input_tokens": 12,
+                "gen_ai.usage.output_tokens": 14,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [
+                {
+                    "name": "gen_ai.user.message",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "content": "Hello, say 'Hi' back to me",
+                    },
+                },
+                {
+                    "name": "gen_ai.choice",
+                    "attributes": {
+                        "gen_ai.system": "mistral",
+                        "message": '{"role": "assistant", "content": "Hi there! \\ud83d\\ude0a How can I help you today?"}',
+                        "index": 0,
+                        "finish_reason": "stop",
+                    },
+                },
+            ],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_async_completion_with_temperature(
+    async_client: Mistral, span_exporter: InMemorySpanExporter
+) -> None:
+    response = await async_client.chat.complete_async(
+        model="mistral-small-latest",
+        messages=[{"role": "user", "content": "Write the word 'test'"}],
+        max_tokens=10,
+        temperature=0.0,
+    )
+
+    assert isinstance(response, ChatCompletionResponse)
+    assert response.choices
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_data = extract_span_data(spans[0])
+    assert span_data["attributes"]["gen_ai.request.temperature"] == 0.0
+    assert span_data["attributes"]["gen_ai.request.max_tokens"] == 10
+
+
+def test_instrumentation_idempotency(
+    mistral_api_key: str, span_exporter: InMemorySpanExporter
+) -> None:
+    client = Mistral(api_key=mistral_api_key)
+
+    instrument_mistral(client)
+    instrument_mistral(client)
+
+    assert hasattr(client, "_lilypad_instrumented")
+    assert isinstance(client.chat.complete, FunctionWrapper)
+
+
+def test_multiple_client_instances(
+    mistral_api_key: str, span_exporter: InMemorySpanExporter
+) -> None:
+    client1 = Mistral(api_key=mistral_api_key)
+    client2 = Mistral(api_key=mistral_api_key)
+
+    instrument_mistral(client1)
+    instrument_mistral(client2)
+
+    assert hasattr(client1, "_lilypad_instrumented")
+    assert hasattr(client2, "_lilypad_instrumented")
+    assert isinstance(client1.chat.complete, FunctionWrapper)
+    assert isinstance(client2.chat.complete, FunctionWrapper)
+
+
+@patch("lilypad._internal.otel.mistral.instrument.version")
+def test_package_not_found(
+    mock_version: Mock, mistral_api_key: str, span_exporter: InMemorySpanExporter
+) -> None:
+    mock_version.side_effect = PackageNotFoundError("lilypad-sdk")
+
+    client = Mistral(api_key=mistral_api_key)
+    instrument_mistral(client)
+
+    assert hasattr(client, "_lilypad_instrumented")
+    assert isinstance(client.chat.complete, FunctionWrapper)
+
+
+def test_wrapping_failure_logging(
+    mistral_api_key: str,
+    span_exporter: InMemorySpanExporter,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = Mistral(api_key=mistral_api_key)
+
+    class ReadOnlyChat:
+        @property
+        def complete(self):
+            return Mock()
+
+        @property
+        def complete_async(self):
+            return Mock()
+
+    client.chat = ReadOnlyChat()  # type: ignore[assignment]
+
+    with caplog.at_level("WARNING"):
+        instrument_mistral(client)
+
+    assert "Failed to wrap Mistral.chat.complete" in caplog.text
+
+
+@pytest.mark.vcr()
+def test_sync_error_handling(
+    client: Mistral, span_exporter: InMemorySpanExporter
+) -> None:
+    with pytest.raises(SDKError):
+        client.chat.complete(
+            model="invalid-model-xyz",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=50,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_data = extract_span_data(spans[0])
+    assert span_data["status"]["status_code"] == "ERROR"
+    assert "error.type" in span_data["attributes"]
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_async_error_handling(
+    async_client: Mistral, span_exporter: InMemorySpanExporter
+) -> None:
+    with pytest.raises(SDKError):
+        await async_client.chat.complete_async(
+            model="invalid-model-xyz",
+            messages=[{"role": "user", "content": "Hello"}],
+            max_tokens=50,
+        )
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_data = extract_span_data(spans[0])
+    assert span_data["status"]["status_code"] == "ERROR"
+    assert "error.type" in span_data["attributes"]


### PR DESCRIPTION
### TL;DR

Added test cassettes and test cases for Mistral AI instrumentation in the Lilypad SDK.

### What changed?

Added comprehensive test files for the Mistral AI instrumentation module in the Lilypad SDK. The changes include:
- Created test cassettes for various Mistral API interactions
- Added test cases for both synchronous and asynchronous completions
- Implemented tests for different parameter configurations (temperature, top_p, etc.)
- Added error handling test cases
- Created tests for instrumentation idempotency and multiple client instances

### How to test?

Run the test suite with pytest:
```bash
cd sdks/python
pytest tests/lilypad/_internal/otel/mistral/test_instrument.py -v
```

### Why make this change?

These tests ensure the Mistral AI instrumentation module correctly captures telemetry data for various API interactions. The tests verify that spans are properly created with the right attributes, events are correctly recorded, and error handling works as expected. This improves the reliability of the OpenTelemetry integration for Mistral AI in the Lilypad SDK.