### PR TITLE
feat: add support for .stream methods that use context managers

### DIFF
--- a/sdks/python/src/lilypad/_internal/otel/anthropic.py
+++ b/sdks/python/src/lilypad/_internal/otel/anthropic.py
@@ -307,13 +307,10 @@ def instrument_anthropic(
 
     if isinstance(client, Anthropic | AnthropicBedrock | AnthropicVertex):
         instrumentor.instrument_generate(client.messages.create)
-        # TODO: add support for `.stream`, which has a context manager
-        # instrumentor.instrument_generate(client.messages.stream, handle_stream=True)
+        instrumentor.instrument_generate(client.messages.stream)
     else:
         instrumentor.instrument_async_generate(client.messages.create)
-        # TODO: add support for `.stream`, which has a context manager
-        # instrumentor.instrument_async_generate(
-        #     client.messages.stream, handle_stream=True
-        # )
+        # NOTE: this method is not awaitable, so we use the sync path for async context managers
+        instrumentor.instrument_generate(client.messages.stream)
 
     _utils.mark_client_as_instrumented(client)

--- a/sdks/python/tests/lilypad/_internal/otel/cassettes/test_anthropic_streaming_with_context_manager.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/cassettes/test_anthropic_streaming_with_context_manager.yaml
@@ -1,0 +1,130 @@
+interactions:
+- request:
+    body: '{"max_tokens":200,"messages":[{"role":"user","content":"Hello, say ''Hi''
+      back to me"}],"model":"claude-3-5-sonnet-20241022","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '137'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.63.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_01EVsHjET3nRHxwr1bbuxK96","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":2,"service_tier":"standard"}}              }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi!"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        How are you today?"}               }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0  }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":10}}
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"     }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Thu, 21 Aug 2025 19:11:38 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-21T19:11:37Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-21T19:11:37Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-21T19:11:37Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-21T19:11:37Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+      x-envoy-upstream-service-time:
+      - '1433'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/cassettes/test_async_anthropic_streaming_with_context_manager.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/cassettes/test_async_anthropic_streaming_with_context_manager.yaml
@@ -1,0 +1,130 @@
+interactions:
+- request:
+    body: '{"max_tokens":200,"messages":[{"role":"user","content":"Hello, say ''Hi''
+      back to me"}],"model":"claude-3-5-sonnet-20241022","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '137'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.63.0
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 0.63.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"id":"msg_0148n4FQ8wNUD2Gsp1rqkgEf","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":2,"service_tier":"standard"}}  }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi!"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        How are you?"}}
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0          }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":9}       }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"              }
+
+
+        '
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Thu, 21 Aug 2025 19:30:17 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-ratelimit-input-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-08-21T19:30:15Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '80000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '80000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-08-21T19:30:15Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-08-21T19:30:15Z'
+      anthropic-ratelimit-tokens-limit:
+      - '480000'
+      anthropic-ratelimit-tokens-remaining:
+      - '480000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-08-21T19:30:15Z'
+      cf-cache-status:
+      - DYNAMIC
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+      x-envoy-upstream-service-time:
+      - '1454'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/cassettes/test_async_openai_streaming_with_context_manager.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/cassettes/test_async_openai_streaming_with_context_manager.yaml
@@ -1,0 +1,122 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Hello, say ''Hi'' back to me"}],"model":"gpt-4o-mini","max_tokens":200,"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 1.98.0
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - chat.completions.stream
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 1.98.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"VkVcKt"}
+
+
+        data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"Hi"},"logprobs":null,"finish_reason":null}],"obfuscation":"fRtEV0"}
+
+
+        data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}],"obfuscation":"opezHqo"}
+
+
+        data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        How"},"logprobs":null,"finish_reason":null}],"obfuscation":"iFID"}
+
+
+        data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}],"obfuscation":"ARmy"}
+
+
+        data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}],"obfuscation":"JSwMpV"}
+
+
+        data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        assist"},"logprobs":null,"finish_reason":null}],"obfuscation":"V"}
+
+
+        data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        you"},"logprobs":null,"finish_reason":null}],"obfuscation":"WP0C"}
+
+
+        data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        today"},"logprobs":null,"finish_reason":null}],"obfuscation":"Xo"}
+
+
+        data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"obfuscation":"w1zQlFn"}
+
+
+        data: {"id":"chatcmpl-C75q393ZLGsfaJfHN5jgzJm4jyUGU","object":"chat.completion.chunk","created":1755806775,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"AP"}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Thu, 21 Aug 2025 20:06:15 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-processing-ms:
+      - '364'
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '515'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999991'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/sdks/python/tests/lilypad/_internal/otel/cassettes/test_openai_streaming_with_context_manager.yaml
+++ b/sdks/python/tests/lilypad/_internal/otel/cassettes/test_openai_streaming_with_context_manager.yaml
@@ -1,0 +1,122 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"Hello, say ''Hi'' back to me"}],"model":"gpt-4o-mini","max_tokens":200,"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '122'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.98.0
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - chat.completions.stream
+      x-stainless-lang:
+      - python
+      x-stainless-package-version:
+      - 1.98.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: 'data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"7ITNWD"}
+
+
+        data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"Hi"},"logprobs":null,"finish_reason":null}],"obfuscation":"hjJ6Zd"}
+
+
+        data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}],"obfuscation":"90ElmCG"}
+
+
+        data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        How"},"logprobs":null,"finish_reason":null}],"obfuscation":"OT6O"}
+
+
+        data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}],"obfuscation":"P1sk"}
+
+
+        data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}],"obfuscation":"qNsaLY"}
+
+
+        data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        assist"},"logprobs":null,"finish_reason":null}],"obfuscation":"Z"}
+
+
+        data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        you"},"logprobs":null,"finish_reason":null}],"obfuscation":"6jPf"}
+
+
+        data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"
+        today"},"logprobs":null,"finish_reason":null}],"obfuscation":"Ef"}
+
+
+        data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{"content":"?"},"logprobs":null,"finish_reason":null}],"obfuscation":"qPyzYXE"}
+
+
+        data: {"id":"chatcmpl-C75of9t9mw2bHivO4QXBrARF2bArh","object":"chat.completion.chunk","created":1755806689,"model":"gpt-4o-mini-2024-07-18","service_tier":"default","system_fingerprint":"fp_560af6e559","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"xs"}
+
+
+        data: [DONE]
+
+
+        '
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Thu, 21 Aug 2025 20:04:49 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-processing-ms:
+      - '252'
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '330'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999991'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
Add support for the `.stream` methods for OpenAI and Anthropic, which use context managers.

Note that async context managers are not awaitable, so we instrument those methods using the sync path. I've added notes to that effect in the code so it's clear.